### PR TITLE
Compile cleanly with -prod with latest V b68784a (after os.exec() deprecation)

### DIFF
--- a/android/util/util.v
+++ b/android/util/util.v
@@ -67,7 +67,7 @@ pub fn verbosity_print_cmd(args []string, verbosity int) {
 
 pub fn run_or_exit(args []string) string {
 	res := run(args)
-	if res.exit_code > 0 {
+	if res.exit_code != 0 {
 		eprintln('${args[0]} failed with return code $res.exit_code')
 		eprintln(res.output)
 		exit(1)
@@ -76,7 +76,10 @@ pub fn run_or_exit(args []string) string {
 }
 
 pub fn run(args []string) os.Result {
-	res := os.exec(args.join(' ')) or { os.Result{1, ''} }
+	res := os.execute(args.join(' '))
+	if res.exit_code < 0 {
+		return os.Result{1, ''}
+	}
 	return res
 }
 

--- a/java/java.v
+++ b/java/java.v
@@ -23,12 +23,14 @@ pub fn jre_version() string {
 	mut version := ''
 
 	// Fast - but not most reliable way
-	java_version := os.exec(java + ' -version') or { os.Result{1, ''} }
-	output := java_version.output
-	mut re := regex.regex_opt(r'.*(\d+\.?\d*\.?\d*)') or { panic(err.msg) }
-	start, _ := re.match_string(output)
-	if start >= 0 && re.groups.len > 0 {
-		version = output[re.groups[0]..re.groups[1]]
+	java_version := os.execute(java + ' -version')
+	if java_version.exit_code == 0 {
+		output := java_version.output
+		mut re := regex.regex_opt(r'.*(\d+\.?\d*\.?\d*)') or { panic(err.msg) }
+		start, _ := re.match_string(output)
+		if start >= 0 && re.groups.len > 0 {
+			version = output[re.groups[0]..re.groups[1]]
+		}
 	}
 	// Slow - but more reliable way, using Java itself
 	if version == '' && jdk_found() {
@@ -41,7 +43,10 @@ pub fn jre_version() string {
 		os.chdir(java_source_dir)
 		os.write_file(java_source_file, java_source) or { return '' }
 		if os.system(javac + ' $java_source_file') == 0 {
-			r := os.exec(java + ' $java_source_exe') or { return '' }
+			r := os.execute(java + ' $java_source_exe')
+			if r.exit_code != 0 {
+				return ''
+			}
 			version = r.output
 		}
 		os.chdir(pwd)
@@ -67,12 +72,11 @@ pub fn jdk_version() string {
 	mut version := ''
 
 	// Fast - but not most reliable way
-	java_version := os.exec(java + ' -version') or { os.Result{1, ''} }
-	output := java_version.output
-
+	java_version := os.execute(java + ' -version')
 	if java_version.exit_code != 0 {
 		return ''
 	}
+	output := java_version.output
 
 	mut re := regex.regex_opt(r'.*(\d+\.?\d*\.?\d*)') or { panic(err.msg) }
 	start, _ := re.match_string(output)
@@ -90,7 +94,10 @@ pub fn jdk_version() string {
 		os.chdir(java_source_dir)
 		os.write_file(java_source_file, java_source) or { return '' }
 		if os.system(javac + ' $java_source_file') == 0 {
-			r := os.exec(java + ' $java_source_exe') or { return '' }
+			r := os.execute(java + ' $java_source_exe')
+			if r.exit_code != 0 {
+				return ''
+			}
 			version = r.output
 		}
 		os.chdir(pwd)

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -35,7 +35,10 @@ pub fn version() string {
 	mut version := ''
 	v := vexe()
 	if v != '' {
-		v_version := os.exec(v + ' -version') or { os.Result{1, ''} }
+		v_version := os.execute(v + ' -version')
+		if v_version.exit_code != 0 {
+			return version
+		}
 		output := v_version.output
 		mut re := regex.regex_opt(r'.*(\d+\.?\d*\.?\d*)') or { panic(err.msg) }
 		start, _ := re.match_string(output)
@@ -51,7 +54,10 @@ pub fn version_commit_hash() string {
 	mut hash := ''
 	v := vexe()
 	if v != '' {
-		v_version := os.exec(v + ' -version') or { os.Result{1, ''} }
+		v_version := os.execute(v + ' -version')
+		if v_version.exit_code != 0 {
+			return ''
+		}
 		output := v_version.output
 		mut re := regex.regex_opt(r'.*\d+\.?\d*\.?\d* ([a-fA-F0-9]{7,})') or { panic(err.msg) }
 		start, _ := re.match_string(output)


### PR DESCRIPTION
Changes os.exec() (that returned an optional) to os.execute() (which does not).

Allows clean compilation without warnings/errors with latest V.