### PR TITLE
sdk: init const earlier for possible_sdk_paths_xxx

### DIFF
--- a/android/sdk/sdk.v
+++ b/android/sdk/sdk.v
@@ -11,13 +11,6 @@ const (
 	home = os.home_dir()
 )
 
-pub const (
-	default_api_level                 = os.file_name(default_platforms_dir()).all_after('android-')
-	default_build_tools_version       = os.file_name(default_build_tools_dir())
-	min_supported_api_level           = '21'
-	min_supported_build_tools_version = '24.0.3'
-)
-
 // Possible default locations of the SDK
 // https://stackoverflow.com/a/47630714/1904615
 const (
@@ -32,6 +25,13 @@ const (
 		os.join_path(home, 'Android/Sdk'),
 		'/usr/local/lib/android/sdk',
 	]
+)
+
+pub const (
+	default_api_level                 = os.file_name(default_platforms_dir()).all_after('android-')
+	default_build_tools_version       = os.file_name(default_build_tools_dir())
+	min_supported_api_level           = '21'
+	min_supported_build_tools_version = '24.0.3'
 )
 
 enum Component {


### PR DESCRIPTION
Currently `Detect OS type at runtime` in the same file  gets an empty dir array at first run.
This commit fixes this and makes default location search more useful.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
