### PR TITLE
ci: skip incredible slow macOS step in example builds

### DIFF
--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -20,7 +20,7 @@ jobs:
     needs: no-scheduling
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         java-version: [8, 15]
         android-api: [27, 30]
 


### PR DESCRIPTION
macOS CI in the examples matrix builds is incredible slow.
The examples are built on macOS already in another CI run - so to speed things up this is introduced.