### PR TITLE
readme: Libssl requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dependencies:
  * Java (JDK) >= 8
  * Android SDK
  * Android NDK
+ * libssl / OpenSSL
 
 (**no** Android Studio required)
 


### PR DESCRIPTION
When building vab, I got a simple error on a fresh new install of Ubuntu:
```
sheat@ubuntu:~/Documents/vab$ v vab.v 
builder error: 'openssl/rand.h' not found
```

This pull request add to the readme the OpenSSL / libssl dependency.

On my case, this require the installation of "libssl-dev".

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
