### PR TITLE
compile: use non-deprecated path for sysroot/includes

### DIFF
--- a/android/compile.v
+++ b/android/compile.v
@@ -196,9 +196,14 @@ pub fn compile(opt CompileOptions) bool {
 	// TODO if full_screen
 	defines << '-DANDROID_FULLSCREEN'
 
-	ndk_root := ndk.root_version(opt.ndk_version)
-	// NDK headers
-	includes << ['-I"$ndk_root/sysroot/usr/include"', '-I"$ndk_root/sysroot/usr/include/android"']
+	// Include NDK headers
+	// NOTE "$ndk_root/sysroot/usr/include" was deprecated since NDK r19
+	ndk_sysroot := ndk.sysroot_path(opt.ndk_version) or {
+		panic('$err_sig: getting NDK sysroot path. $err')
+	}
+	includes << ['-I"' + os.join_path(ndk_sysroot, 'usr', 'include') + '"',
+		'-I"' +
+		os.join_path(ndk_sysroot, 'usr', 'include', 'android') + '"']
 
 	// Sokol
 	if '-cg' in opt.v_flags || '-g' in opt.v_flags {

--- a/android/ndk/ndk.v
+++ b/android/ndk/ndk.v
@@ -256,8 +256,23 @@ pub fn libs_path(ndk_version string, arch string, api_level string) ?string {
 	*/
 	if !os.is_dir(libs_path) {
 		return error(@MOD + '.' + @FN +
-			' couldn\'t locate libraries path "$libs_path". You could try with a newer ndk version.')
+			' couldn\'t locate libraries path "$libs_path". You could try with a newer NDK version.')
 	}
 
 	return libs_path
+}
+
+[inline]
+pub fn sysroot_path(ndk_version string) ?string {
+	mut host_architecture := host_arch()
+
+	mut sysroot_path := os.join_path(root_version(ndk_version), 'toolchains', 'llvm',
+		'prebuilt', host_architecture, 'sysroot')
+
+	if !os.is_dir(sysroot_path) {
+		return error(@MOD + '.' + @FN +
+			' couldn\'t locate sysroot at "$sysroot_path". You could try with a newer NDK version (>= r19).')
+	}
+
+	return sysroot_path
 }


### PR DESCRIPTION
Fixes #147 