### PR TITLE
all: add preliminary Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         export ANDROID_NDK_ROOT=""
         export VEXE=./v
         vab/vab install auto
+        /home/runner/.cache/v/android/sdk/cmdline-tools/tools/bin/sdkmanager --version
 
     - name: Run vab doctor
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
         export ANDROID_NDK_ROOT=""
         export VEXE=./v
         vab/vab install auto
-        /home/runner/.cache/v/android/sdk/cmdline-tools/tools/bin/sdkmanager --version
 
     - name: Run vab doctor
       run: |

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
 
     - name: Checkout V
       uses: actions/checkout@v2

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -120,34 +120,34 @@ jobs:
         adb uninstall io.v.ci.vab.apk.examples.tetris
 
         # V UI
-        git clone --depth 1 https://github.com/vlang/ui
-        cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
+        #git clone --depth 1 https://github.com/vlang/ui
+        #cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
 
-        declare -a v_ui_examples=('rectangles.v' 'calculator.v')
+        #declare -a v_ui_examples=('rectangles.v' 'calculator.v')
 
-        for example in "${v_ui_examples[@]}"; do
-          package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
-          package_id=$( echo "v$package_id" )
+        #for example in "${v_ui_examples[@]}"; do
+          #package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
+          #package_id=$( echo "v$package_id" )
 
-          # APK
-          vab/vab -cg --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
+          ## APK
+          #vab/vab -cg --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
 
-          # AAB
-          vab/vab -cg --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
+          ## AAB
+          #vab/vab -cg --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
 
-          # Remove if cache is run
-          adb uninstall "io.v.apk.ui.$package_id"
-          adb uninstall "io.v.aab.ui.$package_id"
-        done
+          ## Remove if cache is run
+          #adb uninstall "io.v.apk.ui.$package_id"
+          #adb uninstall "io.v.aab.ui.$package_id"
+        #done
 
-        # Output test
-        adb -e logcat -c
-        vab/vab -cg --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
-        sleep 2
-        adb -e logcat -d > /tmp/logcat.dump.txt
-        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        ## Output test
+        #adb -e logcat -c
+        #vab/vab -cg --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
+        #sleep 2
+        #adb -e logcat -d > /tmp/logcat.dump.txt
+        #cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
 
-        # Remove if cache is run
-        adb uninstall io.v.ui.ci.examples.calculator
+        ## Remove if cache is run
+        #adb uninstall io.v.ui.ci.examples.calculator
 
         adb -s emulator-5554 emu kill

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 11
+        java-version: 8
 
     - name: Checkout V
       uses: actions/checkout@v2

--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        java-version: [8, 15]
+        java-version: [11, 15]
         android-api: [27, 30]
     timeout-minutes: 30
     env:

--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        java-version: [11, 15]
+        java-version: [8,11,15]
         android-api: [27, 30]
     timeout-minutes: 30
     env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ based devices.
 
 # Install
 
-Currently Linux and macOS build hosts are supported.
+Linux, macOS and Windows build hosts are supported.
 
 ```bash
 git clone https://github.com/vlang/vab.git
@@ -16,10 +16,8 @@ cd vab
 v vab.v
 ```
 
-
 **Note** `vab` use V's `net.http` module which currently requires the development files for libssl / OpenSSL.
 These can be installed as [described](https://github.com/vlang/v#v-nethttp-netwebsocket-v-install) in V's own documentation.
-
 
 ## Symlink (optional)
 You can symlink `vab` to your `$PATH` so it works as a global shell command.
@@ -31,11 +29,11 @@ sudo ln -s /path/to/vab /usr/local/bin/vab
 
 Dependencies:
  * V
- * Java (JDK) >= 8
+ * Java (JDK) >= 8 (>= 9 on Windows)
  * Android SDK
  * Android NDK
 
-(**no** Android Studio required)
+(Android Studio is **NOT** required)
 
 If `vab` fail to detect your environment you can set ENV variables
 to help it:
@@ -126,6 +124,10 @@ If you have nerves to let it try and figure things out automatically simply do:
 
 ## Java
 
+### Windows
+
+OpenJDK can be installed via [https://adoptium.net/](https://adoptium.net/).
+
 ### macOS
 
 Installing Java JDK using homebrew
@@ -152,4 +154,6 @@ Installed API levels can be listed with `vab --list-apis`.
 
 # Troubleshooting
 
-Android is a complex ecosystem - please consult our [FAQ](docs/FAQ.md) for answers to frequently asked questions.
+Android is a complex ecosystem that has differences between
+build hosts and tool versions - please consult our [FAQ](docs/FAQ.md)
+for answers to frequently asked questions.

--- a/android/compile.v
+++ b/android/compile.v
@@ -215,8 +215,7 @@ pub fn compile(opt CompileOptions) bool {
 		panic('$err_sig: getting NDK sysroot path. $err')
 	}
 	includes << ['-I"' + os.join_path(ndk_sysroot, 'usr', 'include') + '"',
-		'-I"' +
-		os.join_path(ndk_sysroot, 'usr', 'include', 'android') + '"']
+		'-I"' + os.join_path(ndk_sysroot, 'usr', 'include', 'android') + '"']
 
 	is_debug_build := '-cg' in opt.v_flags || '-g' in opt.v_flags
 

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -375,8 +375,19 @@ fn install_opt(opt InstallOptions) ?bool {
 		} $else {
 			/*return error('Run the following command in your shell to install "$item":\n' +
 				cmd.join(' '))*/
-			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+
+			win_cmd := [
+				'cmd /c',
+				"'"+yes_cmd,
+				'|' /* TODO Windows */,
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"'+"'"
+			]
+
+			//util.verbosity_print_cmd(cmd, opt.verbosity)
+			println(win_cmd)
+			cmd_res := util.run(win_cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)
 			}

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -378,15 +378,15 @@ fn install_opt(opt InstallOptions) ?bool {
 
 			win_cmd := [
 				'cmd /c',
-				"'"+yes_cmd,
+				'"'+yes_cmd,
 				'|' /* TODO Windows */,
 				sdkmanager(),
 				'--sdk_root="$sdk.root()"',
-				'"$item"'+"'"
+				'"$item"'+'"'
 			]
 
 			//util.verbosity_print_cmd(cmd, opt.verbosity)
-			println(win_cmd)
+			println(win_cmd.join(' '))
 			cmd_res := util.run(win_cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -774,7 +774,7 @@ fn ensure_aapt2(verbosity int) ?bool {
 		}
 		// Download
 		// https://maven.google.com/web/index.html -> com.android.tools.build -> aapt2
-		uos := os.user_os().replace('windows', 'win').replace('macos', 'osx')
+		uos := os.user_os().replace('macos', 'osx')
 		url := env.default_components['aapt2']['bootstrap_url'].replace('{XXX}', uos)
 		file := os.join_path(os.temp_dir(), 'aapt2.jar')
 		// file := os.join_path(dst, 'aapt2.jar')

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -237,7 +237,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'No permission to write in Android SDK root. Please install manually or ensure write access to "$sdk.root()".')
 		} else {
 			return error(@MOD + '.' + @FN + ' ' +
-				'The `sdkmanager` ($sdkmanager()) seems outdated or incompatible with the Java version used". Please fix your setup manually.')
+				'The `sdkmanager` seems outdated or incompatible with the Java version used". Please fix your setup manually.\nPath: "$sdkmanager()"\nVersion: $sdkmanager_version()')
 		}
 	}
 

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -473,11 +473,13 @@ fn ensure_sdkmanager(verbosity int) ?bool {
 		if verbosity > 1 {
 			println('Installing `sdkmanager` to "$dst"...')
 		}
-		os.mkdir_all(dst) or { panic(err) }
+		os.mkdir_all(dst) ?
 		dst_check := os.join_path(dst, 'tools', 'bin')
-		if util.unzip(file, dst) {
-			os.chmod(os.join_path(dst_check, 'sdkmanager'), 0o755) or { panic(err) }
-		}
+
+		util.unzip(file, dst) ?
+
+		os.chmod(os.join_path(dst_check, 'sdkmanager'), 0o755) ?
+
 		if os.is_executable(os.join_path(dst_check, 'sdkmanager')) {
 			if verbosity > 1 {
 				println('`sdkmanager` installed in "$dst_check". SDK root reports "$sdk.root()"')

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -279,7 +279,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+			cmd_res := util.raw_run(cmd)
 			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}
@@ -310,7 +310,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+			cmd_res := util.raw_run(cmd)
 			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}
@@ -354,7 +354,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+			cmd_res := util.raw_run(cmd)
 			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}
@@ -394,7 +394,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+			cmd_res := util.raw_run(cmd)
 			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}
@@ -429,7 +429,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
+			cmd_res := util.raw_run(cmd)
 			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -373,20 +373,15 @@ fn install_opt(opt InstallOptions) ?bool {
 			}
 			return true
 		} $else {
-			/*return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))*/
-
 			win_cmd := [
 				'cmd /c',
-				'"'+yes_cmd,
-				'|' /* TODO Windows */,
-				sdkmanager(),
+				'"' + yes_cmd,
+				'|',
+				'"' + sdkmanager() + '"',
 				'--sdk_root="$sdk.root()"',
-				'"$item"'+'"'
+				'"$item"' + '"',
 			]
-
-			//util.verbosity_print_cmd(cmd, opt.verbosity)
-			println(win_cmd.join(' '))
+			util.verbosity_print_cmd(cmd, opt.verbosity)
 			cmd_res := util.run(win_cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -476,6 +476,7 @@ fn sdkmanager_windows() string {
 	if !os.exists(sdkmanager) {
 		if os.exists_in_system_path('sdkmanager') {
 			sdkmanager = os.find_abs_path_of_executable('sdkmanager') or { '' }
+			sdkmanager = sdkmanager.trim_string_right('.bat')+'.bat'
 		}
 	}
 	// Try detecting it in the SDK
@@ -516,6 +517,9 @@ fn sdkmanager_windows() string {
 }
 
 pub fn sdkmanager() string {
+	$if windows {
+		return sdkmanager_windows()
+	}
 	mut sdkmanager := cache.get_string(@MOD + '.' + @FN)
 	if sdkmanager != '' {
 		return sdkmanager

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -129,7 +129,7 @@ pub fn managable() bool {
 }
 
 pub fn install(components string, verbosity int) int {
-	mut ios := []InstallOptions{}
+	mut iopts := []InstallOptions{}
 	mut ensure_sdk := true
 	// Allows to specify a string list of things to install
 	components_array := components.split(',')
@@ -171,7 +171,7 @@ pub fn install(components string, verbosity int) int {
 					env.default_components['build-tools']['version']
 				platforms_comp := env.default_components['platforms']['name'] + ';' +
 					env.default_components['platforms']['version']
-				ios = [
+				iopts = [
 					InstallOptions{.cmdline_tools, cmdline_tools_comp, verbosity},
 					InstallOptions{.platform_tools, platform_tools_comp, verbosity},
 					InstallOptions{.ndk, ndk_comp, verbosity},
@@ -181,27 +181,27 @@ pub fn install(components string, verbosity int) int {
 				break
 			}
 			'cmdline-tools' {
-				ios << InstallOptions{.cmdline_tools, item, verbosity}
+				iopts << InstallOptions{.cmdline_tools, item, verbosity}
 			}
 			'platform-tools' {
-				ios << InstallOptions{.platform_tools, item, verbosity}
+				iopts << InstallOptions{.platform_tools, item, verbosity}
 			}
 			'ndk' {
-				ios << InstallOptions{.ndk, item, verbosity}
+				iopts << InstallOptions{.ndk, item, verbosity}
 			}
 			'build-tools' {
-				ios << InstallOptions{.build_tools, item, verbosity}
+				iopts << InstallOptions{.build_tools, item, verbosity}
 			}
 			'platforms' {
-				ios << InstallOptions{.platforms, item, verbosity}
+				iopts << InstallOptions{.platforms, item, verbosity}
 			}
 			'bundletool' {
 				ensure_sdk = false
-				ios << InstallOptions{.bundletool, item, verbosity}
+				iopts << InstallOptions{.bundletool, item, verbosity}
 			}
 			'aapt2' {
 				ensure_sdk = false
-				ios << InstallOptions{.aapt2, item, verbosity}
+				iopts << InstallOptions{.aapt2, item, verbosity}
 			}
 			else {
 				eprintln(@MOD + ' ' + @FN + ' unknown component "$component"')
@@ -217,8 +217,10 @@ pub fn install(components string, verbosity int) int {
 		}
 	}
 
-	for io in ios {
-		install_opt(io) or {
+	// TODO Windows: `call sdkmanager --licenses < file-y.txt`
+
+	for iopt in iopts {
+		install_opt(iopt) or {
 			eprintln(err)
 			return 1
 		}
@@ -246,8 +248,6 @@ fn install_opt(opt InstallOptions) ?bool {
 		yes_cmd = 'echo y' // Windows PowerShell
 	}
 
-	// TODO - right now, because of tricky shell escaping, Windows users need to manually
-	// run the install commands
 	if opt.verbosity > 0 {
 		println(@MOD + '.' + @FN + ' installing $opt.dep: "$item"...')
 	}

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -289,13 +289,8 @@ fn install_opt(opt InstallOptions) ?bool {
 			}
 			return true
 		} $else {
-			// return error('Run the following command in your shell to install "$item":\n' + cmd.join(' '))
-			util.verbosity_print_cmd(cmd, opt.verbosity)
-			cmd_res := util.run(cmd)
-			if cmd_res.exit_code > 0 {
-				return error(cmd_res.output)
-			}
-			return true
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
 	} else if opt.dep == .ndk {
 		version_check := item.all_after(';')
@@ -378,8 +373,14 @@ fn install_opt(opt InstallOptions) ?bool {
 			}
 			return true
 		} $else {
-			return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))
+			/*return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))*/
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
 		}
 	}
 	return error(@MOD + '.' + @FN + ' ' + 'unknown install type $opt.dep')

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -760,8 +760,14 @@ pub fn aapt2() string {
 	if !os.exists(aapt2) {
 		aapt2 = os.join_path(util.cache_dir(), 'aapt2')
 	}
-	if !os.is_executable(aapt2) {
-		aapt2 = ''
+	$if !windows {
+		if !os.is_executable(aapt2) {
+			aapt2 = ''
+		}
+	} $else {
+		if !os.exists(aapt2) {
+			aapt2 = ''
+		}
 	}
 	return aapt2
 }

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -246,6 +246,8 @@ fn install_opt(opt InstallOptions) ?bool {
 		yes_cmd = 'echo y' // Windows PowerShell
 	}
 
+	// TODO - right now, because of tricky shell escaping, Windows users need to manually
+	// run the install commands
 	if opt.verbosity > 0 {
 		println(@MOD + '.' + @FN + ' installing $opt.dep: "$item"...')
 	}
@@ -254,50 +256,42 @@ fn install_opt(opt InstallOptions) ?bool {
 	} else if opt.dep == .aapt2 {
 		return ensure_aapt2(opt.verbosity)
 	} else if opt.dep == .cmdline_tools {
-		/*
-		if opt.verbosity > 0 {
-			println(@MOD + '.' + @FN + ' ' +
-				'commandline tools is already installed in "$sdkmanager()".')
-		}
-		*/
-
 		cmd := [
-			yes_cmd+' |' /* TODO Windows */,
+			yes_cmd + ' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
 		]
-		util.verbosity_print_cmd(cmd, opt.verbosity)
-		cmd_res := util.run(cmd)
-		if cmd_res.exit_code > 0 {
-			return error(cmd_res.output)
-		}
-		return true
-	} else if opt.dep == .platform_tools {
-		/*
-		adb_tool := os.join_path(sdk.platform_tools_root(), 'adb')
-		if os.exists(adb_tool) {
-			eprintln('Notice: Skipping install. Platform Tools seem to be installed in "$sdk.platform_tools_root()"...')
+		$if !windows {
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
 			return true
+		} $else {
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
-
-		if opt.verbosity > 0 {
-			println('Installing Platform Tools "$opt.item"...')
-		}
-		*/
+	} else if opt.dep == .platform_tools {
 		// Ignore opt.item for now
 		cmd := [
-			yes_cmd+' |' /* TODO Windows */,
+			yes_cmd + ' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
 		]
-		util.verbosity_print_cmd(cmd, opt.verbosity)
-		cmd_res := util.run(cmd)
-		if cmd_res.exit_code > 0 {
-			return error(cmd_res.output)
+		$if !windows {
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
+		} $else {
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
-		return true
 	} else if opt.dep == .ndk {
 		version_check := item.all_after(';')
 		if version_check != '' {
@@ -313,17 +307,22 @@ fn install_opt(opt InstallOptions) ?bool {
 			println('Installing NDK (Side-by-side) "$item"...')
 		}
 		cmd := [
-			yes_cmd+' |' /* TODO Windows */,
+			yes_cmd + ' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
 		]
-		util.verbosity_print_cmd(cmd, opt.verbosity)
-		cmd_res := util.run(cmd)
-		if cmd_res.exit_code > 0 {
-			return error(cmd_res.output)
+		$if !windows {
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
+		} $else {
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
-		return true
 	} else if opt.dep == .build_tools {
 		version_check := item.all_after(';')
 		if version_check != '' {
@@ -336,17 +335,23 @@ fn install_opt(opt InstallOptions) ?bool {
 		}
 
 		cmd := [
-			yes_cmd+' |' /* TODO Windows */,
+			yes_cmd + ' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
 		]
-		util.verbosity_print_cmd(cmd, opt.verbosity)
-		cmd_res := util.run(cmd)
-		if cmd_res.exit_code > 0 {
-			return error(cmd_res.output)
+
+		$if !windows {
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
+		} $else {
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
-		return true
 	} else if opt.dep == .platforms {
 		v := item.all_after('-')
 		if v.i16() < sdk.min_supported_api_level.i16() {
@@ -355,17 +360,22 @@ fn install_opt(opt InstallOptions) ?bool {
 		}
 
 		cmd := [
-			yes_cmd+' |' /* TODO Windows */,
+			yes_cmd + ' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
 		]
-		util.verbosity_print_cmd(cmd, opt.verbosity)
-		cmd_res := util.run(cmd)
-		if cmd_res.exit_code > 0 {
-			return error(cmd_res.output)
+		$if !windows {
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
+		} $else {
+			return error('Run the following command in your shell to install "$item":\n' +
+				cmd.join(' '))
 		}
-		return true
 	}
 	return error(@MOD + '.' + @FN + ' ' + 'unknown install type $opt.dep')
 }
@@ -482,7 +492,7 @@ fn sdkmanager_windows() string {
 	if !os.exists(sdkmanager) {
 		if os.exists_in_system_path('sdkmanager') {
 			sdkmanager = os.find_abs_path_of_executable('sdkmanager') or { '' }
-			sdkmanager = sdkmanager.trim_string_right('.bat')+'.bat'
+			sdkmanager = sdkmanager.trim_string_right('.bat') + '.bat'
 		}
 	}
 	// Try detecting it in the SDK

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -241,6 +241,11 @@ fn install_opt(opt InstallOptions) ?bool {
 
 	item := opt.item
 
+	mut yes_cmd := 'yes' // Linux / macOS
+	$if windows {
+		yes_cmd = 'echo y' // Windows PowerShell
+	}
+
 	if opt.verbosity > 0 {
 		println(@MOD + '.' + @FN + ' installing $opt.dep: "$item"...')
 	}
@@ -255,8 +260,9 @@ fn install_opt(opt InstallOptions) ?bool {
 				'commandline tools is already installed in "$sdkmanager()".')
 		}
 		*/
+
 		cmd := [
-			'yes |' /* TODO Windows */,
+			yes_cmd+' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
@@ -281,7 +287,7 @@ fn install_opt(opt InstallOptions) ?bool {
 		*/
 		// Ignore opt.item for now
 		cmd := [
-			'yes |' /* TODO Windows */,
+			yes_cmd+' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
@@ -307,7 +313,7 @@ fn install_opt(opt InstallOptions) ?bool {
 			println('Installing NDK (Side-by-side) "$item"...')
 		}
 		cmd := [
-			'yes |' /* TODO Windows */,
+			yes_cmd+' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
@@ -330,7 +336,7 @@ fn install_opt(opt InstallOptions) ?bool {
 		}
 
 		cmd := [
-			'yes |' /* TODO Windows */,
+			yes_cmd+' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',
@@ -349,7 +355,7 @@ fn install_opt(opt InstallOptions) ?bool {
 		}
 
 		cmd := [
-			'yes |' /* TODO Windows */,
+			yes_cmd+' |' /* TODO Windows */,
 			sdkmanager(),
 			'--sdk_root="$sdk.root()"',
 			'"$item"',

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -256,42 +256,66 @@ fn install_opt(opt InstallOptions) ?bool {
 	} else if opt.dep == .aapt2 {
 		return ensure_aapt2(opt.verbosity)
 	} else if opt.dep == .cmdline_tools {
-		cmd := [
-			yes_cmd + ' |' /* TODO Windows */,
-			sdkmanager(),
-			'--sdk_root="$sdk.root()"',
-			'"$item"',
-		]
 		$if !windows {
+			cmd := [
+				yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"',
+			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
 			cmd_res := util.run(cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)
 			}
-			return true
 		} $else {
-			return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))
+			cmd := [
+				'cmd /c',
+				'"' + yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"' + '"',
+			]
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code != 0 {
+				return error(cmd_res.output)
+			}
 		}
+		return true
 	} else if opt.dep == .platform_tools {
 		// Ignore opt.item for now
-		cmd := [
-			yes_cmd + ' |' /* TODO Windows */,
-			sdkmanager(),
-			'--sdk_root="$sdk.root()"',
-			'"$item"',
-		]
 		$if !windows {
+			cmd := [
+				yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"',
+			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
 			cmd_res := util.run(cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)
 			}
-			return true
 		} $else {
-			return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))
+			cmd := [
+				'cmd /c',
+				'"' + yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"' + '"',
+			]
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code != 0 {
+				return error(cmd_res.output)
+			}
 		}
+		return true
 	} else if opt.dep == .ndk {
 		version_check := item.all_after(';')
 		if version_check != '' {
@@ -306,23 +330,36 @@ fn install_opt(opt InstallOptions) ?bool {
 		if opt.verbosity > 0 {
 			println('Installing NDK (Side-by-side) "$item"...')
 		}
-		cmd := [
-			yes_cmd + ' |' /* TODO Windows */,
-			sdkmanager(),
-			'--sdk_root="$sdk.root()"',
-			'"$item"',
-		]
+
 		$if !windows {
+			cmd := [
+				yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"',
+			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
 			cmd_res := util.run(cmd)
 			if cmd_res.exit_code > 0 {
 				return error(cmd_res.output)
 			}
-			return true
 		} $else {
-			return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))
+			cmd := [
+				'cmd /c',
+				'"' + yes_cmd,
+				'|',
+				sdkmanager(),
+				'--sdk_root="$sdk.root()"',
+				'"$item"' + '"',
+			]
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code != 0 {
+				return error(cmd_res.output)
+			}
 		}
+		return true
 	} else if opt.dep == .build_tools {
 		version_check := item.all_after(';')
 		if version_check != '' {

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -377,13 +377,13 @@ fn install_opt(opt InstallOptions) ?bool {
 				'cmd /c',
 				'"' + yes_cmd,
 				'|',
-				'"' + sdkmanager() + '"',
+				sdkmanager(),
 				'--sdk_root="$sdk.root()"',
 				'"$item"' + '"',
 			]
 			util.verbosity_print_cmd(cmd, opt.verbosity)
 			cmd_res := util.run(win_cmd)
-			if cmd_res.exit_code > 0 {
+			if cmd_res.exit_code != 0 {
 				return error(cmd_res.output)
 			}
 			return true

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -498,10 +498,10 @@ fn sdkmanager_windows() string {
 	// Try detecting it in the SDK
 	if sdk.found() {
 		if !os.exists(sdkmanager) {
-			sdkmanager = os.join_path(sdk.tools_root(), 'bin', 'sdkmanager.bat')
+			sdkmanager = os.join_path(sdk.root(), 'cmdline-tools', 'tools', 'bin', 'sdkmanager.bat')
 		}
 		if !os.exists(sdkmanager) {
-			sdkmanager = os.join_path(sdk.root(), 'cmdline-tools', 'tools', 'bin', 'sdkmanager.bat')
+			sdkmanager = os.join_path(sdk.tools_root(), 'bin', 'sdkmanager.bat')
 		}
 		if !os.exists(sdkmanager) {
 			for relative_path in env.possible_relative_to_sdk_sdkmanager_paths {
@@ -567,10 +567,10 @@ pub fn sdkmanager() string {
 	// Try detecting it in the SDK
 	if sdk.found() {
 		if !os.is_executable(sdkmanager) {
-			sdkmanager = os.join_path(sdk.tools_root(), 'bin', 'sdkmanager')
+			sdkmanager = os.join_path(sdk.root(), 'cmdline-tools', 'tools', 'bin', 'sdkmanager')
 		}
 		if !os.is_executable(sdkmanager) {
-			sdkmanager = os.join_path(sdk.root(), 'cmdline-tools', 'tools', 'bin', 'sdkmanager')
+			sdkmanager = os.join_path(sdk.tools_root(), 'bin', 'sdkmanager')
 		}
 		if !os.is_executable(sdkmanager) {
 			for relative_path in env.possible_relative_to_sdk_sdkmanager_paths {

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -237,7 +237,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'No permission to write in Android SDK root. Please install manually or ensure write access to "$sdk.root()".')
 		} else {
 			return error(@MOD + '.' + @FN + ' ' +
-				'The `sdkmanager` seems outdated or incompatible with the Java version used". Please fix your setup manually.\nPath: "$sdkmanager()"\nVersion: $sdkmanager_version()\nRaw version:\n$cmd_res')
+				'The `sdkmanager` seems outdated or incompatible with the Java version used". Please fix your setup manually.\nPath: "$sdkmanager()"\nVersion: $sdkmanager_version()')
 		}
 	}
 

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -289,8 +289,13 @@ fn install_opt(opt InstallOptions) ?bool {
 			}
 			return true
 		} $else {
-			return error('Run the following command in your shell to install "$item":\n' +
-				cmd.join(' '))
+			// return error('Run the following command in your shell to install "$item":\n' + cmd.join(' '))
+			util.verbosity_print_cmd(cmd, opt.verbosity)
+			cmd_res := util.run(cmd)
+			if cmd_res.exit_code > 0 {
+				return error(cmd_res.output)
+			}
+			return true
 		}
 	} else if opt.dep == .ndk {
 		version_check := item.all_after(';')

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -237,7 +237,7 @@ fn install_opt(opt InstallOptions) ?bool {
 				'No permission to write in Android SDK root. Please install manually or ensure write access to "$sdk.root()".')
 		} else {
 			return error(@MOD + '.' + @FN + ' ' +
-				'The `sdkmanager` seems outdated or incompatible with the Java version used". Please fix your setup manually.')
+				'The `sdkmanager` ($sdkmanager()) seems outdated or incompatible with the Java version used". Please fix your setup manually.')
 		}
 	}
 

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -801,7 +801,7 @@ fn ensure_aapt2(verbosity int) ?bool {
 		os.mkdir_all(unpack_path) or {
 			return error(@MOD + '.' + @FN + ' ' + 'failed to install `aapt2`: $err')
 		}
-		util.unzip(file, unpack_path)
+		util.unzip(file, unpack_path) ?
 		// Install
 		aapt2_file := os.join_path(unpack_path, 'aapt2')
 		dst_check := os.join_path(dst, 'aapt2')

--- a/android/keystore.v
+++ b/android/keystore.v
@@ -21,9 +21,9 @@ pub fn resolve_keystore(default_ks Keystore, verbosity int) Keystore {
 			println('Generating "$file"')
 		}
 		keytool := os.join_path(java.jdk_bin_path(), 'keytool')
-		mut dname_args := "'CN=,OU=,O=,L=,S=,C='"
+		mut dname_args := "'CN=Android Debug,OU=,O=Android,L=,S=,C=US'"
 		$if windows {
-			dname_args = '"CN=,OU=,O=,L=,S=,C="'
+			dname_args = '"' + dname_args.trim("'") + '"'
 		}
 		keytool_cmd := [
 			keytool,

--- a/android/keystore.v
+++ b/android/keystore.v
@@ -21,6 +21,10 @@ pub fn resolve_keystore(default_ks Keystore, verbosity int) Keystore {
 			println('Generating "$file"')
 		}
 		keytool := os.join_path(java.jdk_bin_path(), 'keytool')
+		mut dname_args := "'CN=,OU=,O=,L=,S=,C='"
+		$if windows {
+			dname_args = '"CN=,OU=,O=,L=,S=,C="'
+		}
 		keytool_cmd := [
 			keytool,
 			'-genkeypair',
@@ -30,7 +34,8 @@ pub fn resolve_keystore(default_ks Keystore, verbosity int) Keystore {
 			'-keypass android',
 			'-keyalg RSA',
 			'-validity 10000',
-			"-dname 'CN=,OU=,O=,L=,S=,C='",
+			'-dname',
+			dname_args,
 		]
 		util.verbosity_print_cmd(keytool_cmd, verbosity)
 		util.run_or_exit(keytool_cmd)

--- a/android/keystore.v
+++ b/android/keystore.v
@@ -21,7 +21,7 @@ pub fn resolve_keystore(default_ks Keystore, verbosity int) Keystore {
 			println('Generating "$file"')
 		}
 		keytool := os.join_path(java.jdk_bin_path(), 'keytool')
-		mut dname_args := "'CN=Android Debug,OU=,O=Android,L=,S=,C=US'"
+		mut dname_args := "'CN=,OU=,O=,L=,S=,C=US'"
 		$if windows {
 			dname_args = '"' + dname_args.trim("'") + '"'
 		}

--- a/android/ndk/ndk.v
+++ b/android/ndk/ndk.v
@@ -206,6 +206,9 @@ pub fn compiler(ndk_version string, arch string, api_level string) ?string {
 
 	mut compiler := os.join_path(root_version(ndk_version), 'toolchains', 'llvm', 'prebuilt',
 		host_architecture, 'bin', arch_is + '-linux-android$eabi$api_level-clang')
+	$if windows {
+		compiler += '.cmd'
+	}
 	// legacy ndk version setups
 	/*
 	if !os.is_file(compiler) {

--- a/android/ndk/ndk.v
+++ b/android/ndk/ndk.v
@@ -221,6 +221,7 @@ pub fn compiler(ndk_version string, arch string, api_level string) ?string {
 		}
 	}
 	*/
+
 	if !os.is_file(compiler) {
 		return error(@MOD + '.' + @FN +
 			' couldn\'t locate compiler "$compiler". You could try with a newer ndk version.')

--- a/android/package.v
+++ b/android/package.v
@@ -305,18 +305,37 @@ fn package_aab(opt PackageOptions) bool {
 	if opt.verbosity > 1 {
 		println('Compiling resources')
 	}
-	// aapt2 compile project/app/src/main/res/**/* -o compiled_resources
-	aapt2_cmd := [
-		aapt2,
-		'compile',
-		os.join_path(res_path, '**', '*'),
-		'-o',
-		'compiled_resources.tmp.zip',
-	]
-	util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
-	util.run_or_exit(aapt2_cmd)
-
-	util.unzip('compiled_resources.tmp.zip', 'compiled_resources') or { panic(err) }
+	$if !windows {
+		// aapt2 compile project/app/src/main/res/**/* -o compiled_resources
+		aapt2_cmd := [
+			aapt2,
+			'compile',
+			os.join_path(res_path, '**', '*'),
+			'-o',
+			'compiled_resources.tmp.zip',
+		]
+		util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
+		util.run_or_exit(aapt2_cmd)
+		util.unzip('compiled_resources.tmp.zip', 'compiled_resources') or { panic(err) }
+	} $else {
+		mut folders := []string{}
+		os.walk_with_context(res_path, &folders, fn (mut folders []string, path string) {
+			if os.is_dir(path) {
+				folders << path
+			}
+		})
+		for folder in folders {
+			aapt2_cmd := [
+				aapt2,
+				'compile',
+				os.join_path(res_path, '**', '*'),
+				'-o',
+				'compiled_resources',
+			]
+			util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
+			util.run_or_exit(aapt2_cmd)
+		}
+	}
 
 	if opt.verbosity > 1 {
 		println('Preparing resources and assets')

--- a/android/package.v
+++ b/android/package.v
@@ -455,6 +455,15 @@ fn package_aab(opt PackageOptions) bool {
 
 	util.zip_folder(staging_path, os.join_path(package_path, 'base.zip')) or { panic(err) }
 
+	// TODO temp CI investigation
+	list_zip_cmd := [
+		'unzip',
+		'-l',
+		os.join_path(package_path, 'base.zip'),
+	]
+	util.verbosity_print_cmd(zip_cmd, opt.verbosity)
+	println(util.run(zip_cmd))
+
 	os.chdir(package_path) or {}
 
 	// java -jar bundletool build-bundle --modules=base.zip --output=bundle.aab

--- a/android/package.v
+++ b/android/package.v
@@ -462,7 +462,7 @@ fn package_aab(opt PackageOptions) bool {
 		os.join_path(package_path, 'base.zip'),
 	]
 	util.verbosity_print_cmd(zip_cmd, opt.verbosity)
-	println(util.run(zip_cmd))
+	println(util.run(list_zip_cmd))
 
 	os.chdir(package_path) or {}
 

--- a/android/package.v
+++ b/android/package.v
@@ -452,6 +452,10 @@ fn package_aab(opt PackageOptions) bool {
 
 	// cd staging; zip -r ../base.zip *
 	os.chdir(staging_path) or {}
+
+	util.zip_files_in_dir(staging_path,os.join_path(package_path, 'base.zip')) or { panic(err) }
+
+	/*
 	zip_cmd := [
 		'zip',
 		'-r',
@@ -460,6 +464,8 @@ fn package_aab(opt PackageOptions) bool {
 	]
 	util.verbosity_print_cmd(zip_cmd, opt.verbosity)
 	util.run_or_exit(zip_cmd)
+	*/
+
 	os.chdir(package_path) or {}
 
 	// java -jar bundletool build-bundle --modules=base.zip --output=bundle.aab

--- a/android/package.v
+++ b/android/package.v
@@ -455,17 +455,6 @@ fn package_aab(opt PackageOptions) bool {
 
 	util.zip_folder(staging_path, os.join_path(package_path, 'base.zip')) or { panic(err) }
 
-	/*
-	zip_cmd := [
-		'zip',
-		'-r',
-		os.join_path(package_path, 'base.zip'),
-		'*',
-	]
-	util.verbosity_print_cmd(zip_cmd, opt.verbosity)
-	util.run_or_exit(zip_cmd)
-	*/
-
 	os.chdir(package_path) or {}
 
 	// java -jar bundletool build-bundle --modules=base.zip --output=bundle.aab

--- a/android/package.v
+++ b/android/package.v
@@ -270,9 +270,7 @@ fn package_apk(opt PackageOptions) bool {
 				mut contents := os.read_file(apksigner) or { '' }
 				if contents != '' && contents.contains('-Djava.ext.dirs=') {
 					contents = contents.replace_once('-Djava.ext.dirs=', '-classpath ')
-					os.write_file(patched_apksigner, contents) or {
-						patched_apksigner = apksigner
-					}
+					os.write_file(patched_apksigner, contents) or { patched_apksigner = apksigner }
 				} else {
 					patched_apksigner = apksigner
 				}

--- a/android/package.v
+++ b/android/package.v
@@ -327,18 +327,18 @@ fn package_aab(opt PackageOptions) bool {
 		os.walk_with_context(res_path, &files, fn (mut files []string, path string) {
 			files << path
 		})
+		os.mkdir(compiled_resources_path) or {}
 		for file in files {
 			aapt2_cmd := [
 				aapt2,
 				'compile',
 				'"$file"',
 				'-o',
-				'compiled_resources.tmp.zip',
+				compiled_resources_path,
 			]
 			util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
 			util.run_or_exit(aapt2_cmd)
 		}
-		util.unzip('compiled_resources.tmp.zip', compiled_resources_path) or { panic(err) }
 	}
 
 	if opt.verbosity > 1 {

--- a/android/package.v
+++ b/android/package.v
@@ -453,7 +453,7 @@ fn package_aab(opt PackageOptions) bool {
 	// cd staging; zip -r ../base.zip *
 	os.chdir(staging_path) or {}
 
-	util.zip_files_in_dir(staging_path,os.join_path(package_path, 'base.zip')) or { panic(err) }
+	util.zip_folder(staging_path, os.join_path(package_path, 'base.zip')) or { panic(err) }
 
 	/*
 	zip_cmd := [

--- a/android/package.v
+++ b/android/package.v
@@ -461,7 +461,7 @@ fn package_aab(opt PackageOptions) bool {
 		'-l',
 		os.join_path(package_path, 'base.zip'),
 	]
-	util.verbosity_print_cmd(zip_cmd, opt.verbosity)
+	util.verbosity_print_cmd(list_zip_cmd, opt.verbosity)
 	println(util.run(list_zip_cmd))
 
 	os.chdir(package_path) or {}

--- a/android/package.v
+++ b/android/package.v
@@ -193,7 +193,11 @@ fn package_apk(opt PackageOptions) bool {
 	collected_libs := os.walk_ext(os.join_path(build_path, 'lib'), '.so')
 
 	for lib in collected_libs {
-		lib_s := lib.replace(build_path + os.path_separator, '')
+		mut lib_s := lib.replace(build_path + os.path_separator, '')
+		$if windows {
+			// NOTE This is necessary for paths to work when packaging up on Windows
+			lib_s = lib_s.replace(os.path_separator, '/')
+		}
 		aapt_cmd = [
 			aapt,
 			'add',

--- a/android/package.v
+++ b/android/package.v
@@ -466,7 +466,7 @@ fn package_aab(opt PackageOptions) bool {
 	// Caused by: java.util.zip.ZipException: invalid CEN header (bad signature)
 	jdk_semantic_version := semver.from(java.jdk_version()) or {
 		panic(@MOD + '.' + @FN + ':' + @LINE +
-			' error converting jdk_version "$jdk_version" to semantic version.\nsemver: $err')
+			' error converting jdk_version "$java.jdk_version()" to semantic version.\nsemver: $err')
 	}
 	if jdk_semantic_version.le(semver.build(1, 8, 0)) {
 		$if !windows {

--- a/android/package.v
+++ b/android/package.v
@@ -326,7 +326,9 @@ fn package_aab(opt PackageOptions) bool {
 	} $else {
 		mut files := []string{}
 		os.walk_with_context(res_path, &files, fn (mut files []string, path string) {
-			files << path
+			if os.is_file(path) {
+				files << path
+			}
 		})
 		os.mkdir(compiled_resources_path) or {}
 		for file in files {

--- a/android/package.v
+++ b/android/package.v
@@ -333,11 +333,12 @@ fn package_aab(opt PackageOptions) bool {
 				'compile',
 				'"$file"',
 				'-o',
-				compiled_resources_path + '\\',
+				'compiled_resources.tmp.zip',
 			]
 			util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
 			util.run_or_exit(aapt2_cmd)
 		}
+		util.unzip('compiled_resources.tmp.zip', compiled_resources_path) or { panic(err) }
 	}
 
 	if opt.verbosity > 1 {

--- a/android/package.v
+++ b/android/package.v
@@ -306,6 +306,7 @@ fn package_aab(opt PackageOptions) bool {
 		println('Compiling resources')
 	}
 
+	compiled_resources_path := 'compiled_resources'
 	// https://developer.android.com/studio/command-line/aapt2#compile
 	// NOTE aapt2 compile project/app/src/main/res/**/* -o compiled_resources
 	// The above expansion of "*" does not work on all platforms - so on Windows we gather the files manually.
@@ -320,7 +321,7 @@ fn package_aab(opt PackageOptions) bool {
 		]
 		util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
 		util.run_or_exit(aapt2_cmd)
-		util.unzip('compiled_resources.tmp.zip', 'compiled_resources') or { panic(err) }
+		util.unzip('compiled_resources.tmp.zip', compiled_resources_path) or { panic(err) }
 	} $else {
 		mut files := []string{}
 		os.walk_with_context(res_path, &files, fn (mut files []string, path string) {
@@ -332,7 +333,7 @@ fn package_aab(opt PackageOptions) bool {
 				'compile',
 				'"$file"',
 				'-o',
-				'compiled_resources',
+				compiled_resources_path + '\\',
 			]
 			util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
 			util.run_or_exit(aapt2_cmd)
@@ -365,7 +366,7 @@ fn package_aab(opt PackageOptions) bool {
 		util.run_or_exit(aapt2_link_cmd)
 	} $else {
 		mut files := []string{}
-		os.walk_with_context(res_path, &files, fn (mut files []string, path string) {
+		os.walk_with_context(compiled_resources_path, &files, fn (mut files []string, path string) {
 			if path.ends_with('.flat') {
 				files << path
 			}

--- a/android/package.v
+++ b/android/package.v
@@ -452,7 +452,7 @@ fn package_aab(opt PackageOptions) bool {
 		// Error message we are trying to prevent:
 		// -Djava.ext.dirs=C:<path>lib is not supported.  Use -classpath instead.
 		if jdk_semantic_version.gt(semver.build(1, 8, 0)) && os.exists(dx) {
-			mut patched_dx := os.join_path(os.dir(dx), os.filename(dx).all_before_last('.') +
+			mut patched_dx := os.join_path(os.dir(dx), os.file_name(dx).all_before_last('.') +
 				'_patched.bat')
 			if !os.exists(patched_dx) {
 				mut dx_contents := os.read_file(dx) or { '' }

--- a/android/package.v
+++ b/android/package.v
@@ -270,7 +270,7 @@ fn package_apk(opt PackageOptions) bool {
 				mut contents := os.read_file(apksigner) or { '' }
 				if contents != '' && contents.contains('-Djava.ext.dirs=') {
 					contents = contents.replace_once('-Djava.ext.dirs=', '-classpath ')
-					os.write_file(patched_apksigner, dx_contents) or {
+					os.write_file(patched_apksigner, contents) or {
 						patched_apksigner = apksigner
 					}
 				} else {

--- a/android/package.v
+++ b/android/package.v
@@ -166,7 +166,7 @@ fn package_apk(opt PackageOptions) bool {
 		dx,
 		'--verbose',
 		'--dex',
-		'--output="' + os.join_path('bin', 'classes.dex') + '"',
+		'--output=' + os.join_path('bin', 'classes.dex'),
 		'obj' /* obj_path, */,
 	]
 	util.verbosity_print_cmd(dx_cmd, opt.verbosity)

--- a/android/package.v
+++ b/android/package.v
@@ -316,7 +316,7 @@ fn package_aab(opt PackageOptions) bool {
 	util.verbosity_print_cmd(aapt2_cmd, opt.verbosity)
 	util.run_or_exit(aapt2_cmd)
 
-	util.unzip('compiled_resources.tmp.zip', 'compiled_resources')
+	util.unzip('compiled_resources.tmp.zip', 'compiled_resources') or { panic(err) }
 
 	if opt.verbosity > 1 {
 		println('Preparing resources and assets')
@@ -332,15 +332,11 @@ fn package_aab(opt PackageOptions) bool {
 		'--proto-format',
 		'-o',
 		'temporary.apk',
-		'-I',
-		android_runtime,
-		'--manifest',
-		os.join_path(package_path, 'AndroidManifest.xml'),
+		'-I "' + android_runtime + '"',
+		'--manifest "' + os.join_path(package_path, 'AndroidManifest.xml') + '"',
 		'-R',
-		//'compiled_resources'
 		os.join_path('compiled_resources', '*.flat'),
-		'-A',
-		assets_path,
+		'-A "' + assets_path + '"',
 		'--auto-add-overlay --java gen',
 	]
 	util.verbosity_print_cmd(aapt2_link_cmd, opt.verbosity)
@@ -363,7 +359,7 @@ fn package_aab(opt PackageOptions) bool {
 		'-source 1.7',
 		'-target 1.7',
 		//'-bootclasspath ' + os.join_path(java.jre_root(),'lib','rt.jar')
-		'-bootclasspath ' + android_runtime,
+		'-bootclasspath "' + android_runtime + '"',
 		//'-classpath ' + android_runtime,
 		'-d classes',
 		'-classpath .',
@@ -375,7 +371,7 @@ fn package_aab(opt PackageOptions) bool {
 	util.run_or_exit(javac_cmd)
 
 	// unzip temporary.apk -d staging
-	util.unzip('temporary.apk', staging_path)
+	util.unzip('temporary.apk', staging_path) or { panic(err) }
 
 	os.mkdir_all(os.join_path(staging_path, 'manifest')) or { panic(err) }
 	os.mv(os.join_path(staging_path, 'AndroidManifest.xml'), os.join_path(staging_path,
@@ -444,7 +440,7 @@ fn package_aab(opt PackageOptions) bool {
 		keystore.password,
 		'-keypass',
 		keystore.alias_password,
-		tmp_product,
+		'"' + tmp_product + '"',
 		keystore.alias,
 	]
 	util.verbosity_print_cmd(jarsigner_cmd, opt.verbosity)
@@ -454,11 +450,11 @@ fn package_aab(opt PackageOptions) bool {
 	bundletool_validate_cmd := [
 		java_exe,
 		'-jar',
-		bundletool,
+		'"' + bundletool + '"',
 		'validate',
 		'--bundle',
 		// tmp_unsigned_product
-		tmp_product,
+		'"' + tmp_product + '"',
 	]
 	util.verbosity_print_cmd(bundletool_validate_cmd, opt.verbosity)
 	// println(util.run(bundletool_validate_cmd).output)

--- a/android/package.v
+++ b/android/package.v
@@ -87,9 +87,15 @@ fn package_apk(opt PackageOptions) bool {
 
 	javac := os.join_path(java.jdk_bin_path(), 'javac')
 	aapt := os.join_path(build_tools_path, 'aapt')
-	dx := os.join_path(build_tools_path, 'dx')
+	mut dx := os.join_path(build_tools_path, 'dx')
+	$if windows {
+		dx += '.bat'
+	}
 	zipalign := os.join_path(build_tools_path, 'zipalign')
-	apksigner := os.join_path(build_tools_path, 'apksigner')
+	mut apksigner := os.join_path(build_tools_path, 'apksigner')
+	$if windows {
+		apksigner += '.bat'
+	}
 
 	// work_dir := opt.work_dir
 	// VAPK_OUT=${VAPK}/..
@@ -124,11 +130,11 @@ fn package_apk(opt PackageOptions) bool {
 		'-v',
 		'-f',
 		'-m',
-		'-M ' + os.join_path(package_path, 'AndroidManifest.xml'),
-		'-S ' + res_path,
-		'-J ' + src_path,
-		'-A ' + assets_path,
-		'-I ' + android_runtime /* '--target-sdk-version ${ANDROIDTARGET}' */,
+		'-M "' + os.join_path(package_path, 'AndroidManifest.xml') + '"',
+		'-S "' + res_path + '"',
+		'-J "' + src_path + '"',
+		'-A "' + assets_path + '"',
+		'-I "' + android_runtime + '"' /* '--target-sdk-version ${ANDROIDTARGET}' */,
 	]
 	util.verbosity_print_cmd(aapt_cmd, opt.verbosity)
 	util.run_or_exit(aapt_cmd)
@@ -148,7 +154,7 @@ fn package_apk(opt PackageOptions) bool {
 		'-target 1.7',
 		'-classpath .',
 		'-sourcepath src',
-		'-bootclasspath ' + android_runtime,
+		'-bootclasspath "' + android_runtime + '"',
 	]
 	javac_cmd << java_sources
 
@@ -160,7 +166,7 @@ fn package_apk(opt PackageOptions) bool {
 		dx,
 		'--verbose',
 		'--dex',
-		'--output=' + os.join_path('bin', 'classes.dex'),
+		'--output="' + os.join_path('bin', 'classes.dex') + '"',
 		'obj' /* obj_path, */,
 	]
 	util.verbosity_print_cmd(dx_cmd, opt.verbosity)
@@ -172,11 +178,11 @@ fn package_apk(opt PackageOptions) bool {
 		'package',
 		'-v',
 		'-f',
-		'-S ' + res_path,
-		'-M ' + os.join_path(package_path, 'AndroidManifest.xml'),
-		'-A ' + assets_path,
-		'-I ' + android_runtime,
-		'-F ' + tmp_unaligned_product,
+		'-S "' + res_path + '"',
+		'-M "' + os.join_path(package_path, 'AndroidManifest.xml') + '"',
+		'-A "' + assets_path + '"',
+		'-I "' + android_runtime + '"',
+		'-F "' + tmp_unaligned_product + '"',
 		'bin' /* bin_path */,
 	]
 	util.verbosity_print_cmd(aapt_cmd, opt.verbosity)
@@ -192,8 +198,8 @@ fn package_apk(opt PackageOptions) bool {
 			aapt,
 			'add',
 			'-v',
-			tmp_unaligned_product,
-			lib_s,
+			'"' + tmp_unaligned_product + '"',
+			'"' + lib_s + '"',
 		]
 		util.verbosity_print_cmd(aapt_cmd, opt.verbosity)
 		util.run_or_exit(aapt_cmd)
@@ -205,8 +211,8 @@ fn package_apk(opt PackageOptions) bool {
 		zipalign,
 		'-v',
 		'-f 4',
-		tmp_unaligned_product,
-		tmp_unsigned_product,
+		'"' + tmp_unaligned_product + '"',
+		'"' + tmp_unsigned_product + '"',
 	]
 	util.verbosity_print_cmd(zipalign_cmd, opt.verbosity)
 	util.run_or_exit(zipalign_cmd)
@@ -225,8 +231,8 @@ fn package_apk(opt PackageOptions) bool {
 		'--ks-pass pass:' + keystore.password,
 		'--ks-key-alias "' + keystore.alias + '"',
 		'--key-pass pass:' + keystore.alias_password,
-		'--out ' + tmp_product,
-		tmp_unsigned_product,
+		'--out "' + tmp_product + '"',
+		'"' + tmp_unsigned_product + '"',
 	]
 	util.verbosity_print_cmd(apksigner_cmd, opt.verbosity)
 	util.run_or_exit(apksigner_cmd)
@@ -235,7 +241,7 @@ fn package_apk(opt PackageOptions) bool {
 		apksigner,
 		'verify',
 		'-v',
-		tmp_product,
+		'"' + tmp_product + '"',
 	]
 	util.verbosity_print_cmd(apksigner_cmd, opt.verbosity)
 	util.run_or_exit(apksigner_cmd)
@@ -260,7 +266,10 @@ fn package_aab(opt PackageOptions) bool {
 	java_exe := os.join_path(java.jre_bin_path(), 'java')
 	javac := os.join_path(java.jdk_bin_path(), 'javac')
 	jarsigner := os.join_path(java.jdk_bin_path(), 'jarsigner')
-	dx := os.join_path(build_tools_path, 'dx')
+	mut dx := os.join_path(build_tools_path, 'dx')
+	$if windows {
+		dx += '.bat'
+	}
 	bundletool := env.bundletool() // Run with "java -jar ..."
 	aapt2 := env.aapt2()
 

--- a/android/sdk/sdk.v
+++ b/android/sdk/sdk.v
@@ -31,7 +31,7 @@ pub const (
 	default_api_level                 = os.file_name(default_platforms_dir()).all_after('android-')
 	default_build_tools_version       = os.file_name(default_build_tools_dir())
 	min_supported_api_level           = '21'
-	min_supported_build_tools_version = '24.0.3'
+	min_supported_build_tools_version = '26.0.2'
 )
 
 enum Component {

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -90,6 +90,14 @@ pub fn run(args []string) os.Result {
 	return res
 }
 
+pub fn raw_run(args []string) os.Result {
+	res := os.raw_execute(args.join(' '))
+	if res.exit_code < 0 {
+		return os.Result{1, ''}
+	}
+	return res
+}
+
 pub fn unzip(file string, dir string) ? {
 	if !os.is_dir(dir) {
 		os.mkdir_all(dir) ?

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -108,13 +108,26 @@ pub fn unzip(file string, dir string) ? {
 	// return true
 }
 
-pub fn zip(dir string, file string) bool {
+pub fn zip_files_in_dir(dir string, out_file string) ? {
+	path := dir.trim_right(os.path_separator)
+	mut files := []string{}
+	os.walk_with_context(path, &files, fn (mut files []string, path string) {
+		if os.is_file(path) {
+			files << path
+		}
+	})
+	for mut file in files {
+		file = file.replace(path + os.path_separator, '')
+	}
+
+	szip.zip_files(files, out_file) ?
 	/*
 	eprintln('Zipping ${file} to ${dir}...')
 	mut zip := szip.open(file, 0, szip.m_ronly) or { return false }
 	zip.close()
 	*/
 
+	/*
 	// TODO zip
 	zip_cmd := [
 		'zip',
@@ -123,5 +136,5 @@ pub fn zip(dir string, file string) bool {
 		dir,
 	]
 	run_or_exit(zip_cmd)
-	return true
+	return true*/
 }

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -105,7 +105,7 @@ pub fn unzip(file string, dir string) ? {
 		dir,
 	]
 	run_or_exit(unzip_cmd)*/
-	return true
+	// return true
 }
 
 pub fn zip(dir string, file string) bool {

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -91,7 +91,7 @@ pub fn run(args []string) os.Result {
 }
 
 pub fn raw_run(args []string) os.Result {
-	res := os.raw_execute(args.join(' '))
+	res := unsafe { os.raw_execute(args.join(' ')) }
 	if res.exit_code < 0 {
 		return os.Result{1, ''}
 	}

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -108,33 +108,6 @@ pub fn unzip(file string, dir string) ? {
 	// return true
 }
 
-pub fn zip_files_in_dir(dir string, out_file string) ? {
-	path := dir.trim_right(os.path_separator)
-	mut files := []string{}
-	os.walk_with_context(path, &files, fn (mut files []string, path string) {
-		if os.is_file(path) {
-			files << path
-		}
-	})
-	for mut file in files {
-		file = file.replace(path + os.path_separator, '')
-	}
-
-	szip.zip_files(files, out_file) ?
-	/*
-	eprintln('Zipping ${file} to ${dir}...')
-	mut zip := szip.open(file, 0, szip.m_ronly) or { return false }
-	zip.close()
-	*/
-
-	/*
-	// TODO zip
-	zip_cmd := [
-		'zip',
-		'-f',
-		file,
-		dir,
-	]
-	run_or_exit(zip_cmd)
-	return true*/
+pub fn zip_folder(dir string, out_file string) ? {
+	szip.zip_folder(dir, out_file) ?
 }

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -94,18 +94,7 @@ pub fn unzip(file string, dir string) ? {
 	if !os.is_dir(dir) {
 		os.mkdir_all(dir) ?
 	}
-
 	szip.extract_zip_to_dir(file, dir) ?
-	/*
-	// TODO unzip
-	unzip_cmd := [
-		'unzip',
-		file,
-		'-d',
-		dir,
-	]
-	run_or_exit(unzip_cmd)*/
-	// return true
 }
 
 pub fn zip_folder(dir string, out_file string) ? {

--- a/android/util/util.v
+++ b/android/util/util.v
@@ -3,6 +3,7 @@
 module util
 
 import os
+import szip
 import cache
 
 // Utility functions
@@ -89,14 +90,13 @@ pub fn run(args []string) os.Result {
 	return res
 }
 
-pub fn unzip(file string, dir string) bool {
-	/*
-	eprintln('Unzipping ${file} to ${dir}...')
-	mut zip := szip.open(file, 0, szip.m_ronly) or { return false }
-	zip.extract_entry(dir)
-	zip.close()
-	*/
+pub fn unzip(file string, dir string) ? {
+	if !os.is_dir(dir) {
+		os.mkdir_all(dir) ?
+	}
 
+	szip.extract_zip_to_dir(file, dir) ?
+	/*
 	// TODO unzip
 	unzip_cmd := [
 		'unzip',
@@ -104,7 +104,7 @@ pub fn unzip(file string, dir string) bool {
 		'-d',
 		dir,
 	]
-	run_or_exit(unzip_cmd)
+	run_or_exit(unzip_cmd)*/
 	return true
 }
 

--- a/java/java.v
+++ b/java/java.v
@@ -154,11 +154,13 @@ pub fn jdk_found() bool {
 }
 
 pub fn jdk_bin_path() string {
-	bin_dir := os.find_abs_path_of_executable('javac') or { os.join_path(jdk_root(), 'bin') }
+	bin_dir := os.find_abs_path_of_executable('javac') or {
+		os.join_path(jdk_root(), 'bin', 'javac')
+	}
 	return os.dir(bin_dir)
 }
 
 pub fn jre_bin_path() string {
-	bin_dir := os.find_abs_path_of_executable('java') or { os.join_path(jre_root(), 'bin') }
+	bin_dir := os.find_abs_path_of_executable('java') or { os.join_path(jre_root(), 'bin', 'java') }
 	return os.dir(bin_dir)
 }

--- a/java/java.v
+++ b/java/java.v
@@ -123,8 +123,17 @@ pub fn jre_root() string {
 	if java_home != '' {
 		return java_home.trim_right(os.path_separator)
 	}
-	possible_symlink := os.find_abs_path_of_executable('java') or { return '' }
-	java_home = os.real_path(os.join_path(os.dir(possible_symlink), '..'))
+	$if !windows {
+		possible_symlink := os.find_abs_path_of_executable('java') or { return '' }
+		java_home = os.real_path(os.join_path(os.dir(possible_symlink), '..'))
+	} $else {
+		res := os.execute('where.exe java')
+		if res.exit_code != 0 {
+			java_home = ''
+		} else {
+			java_home = os.dir(res.output.trim('\n\r'))
+		}
+	}
 	return java_home.trim_right(os.path_separator)
 }
 
@@ -142,8 +151,17 @@ pub fn jdk_root() string {
 	if java_home != '' {
 		return java_home.trim_right(os.path_separator)
 	}
-	possible_symlink := os.find_abs_path_of_executable('javac') or { return '' }
-	java_home = os.real_path(os.join_path(os.dir(possible_symlink), '..'))
+	$if !windows {
+		possible_symlink := os.find_abs_path_of_executable('javac') or { return '' }
+		java_home = os.real_path(os.join_path(os.dir(possible_symlink), '..'))
+	} $else {
+		res := os.execute('where.exe javac')
+		if res.exit_code != 0 {
+			java_home = ''
+		} else {
+			java_home = os.dir(res.output.trim('\n\r'))
+		}
+	}
 	java_home = java_home.trim_right(os.path_separator)
 	cache.set_string(@MOD + '.' + @FN, java_home)
 	return java_home

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -50,7 +50,8 @@ pub fn home() string {
 		}
 	} $else {
 		if os.exists(exe) {
-			return os.dir(exe)
+			// Skip the `.bin/` dir
+			return os.dir(os.dir(exe))
 		}
 	}
 	return ''

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -7,12 +7,22 @@ import regex
 
 pub fn vexe() string {
 	mut exe := os.getenv('VEXE')
-	if os.is_executable(exe) {
-		return os.real_path(exe)
-	}
-	possible_symlink := os.find_abs_path_of_executable('v') or { '' }
-	if os.is_executable(possible_symlink) {
-		exe = os.real_path(possible_symlink)
+	$if !windows {
+		if os.is_executable(exe) {
+			return os.real_path(exe)
+		}
+		possible_symlink := os.find_abs_path_of_executable('v') or { '' }
+		if os.is_executable(possible_symlink) {
+			exe = os.real_path(possible_symlink)
+		}
+	} $else {
+		if os.exists(exe) {
+			return os.real_path(exe)
+		}
+		system_path := os.find_abs_path_of_executable('v.bat') or { '' }
+		if os.exists(system_path) {
+			exe = os.real_path(system_path)
+		}
 	}
 	return exe
 }

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -19,7 +19,7 @@ pub fn vexe() string {
 		if os.exists(exe) {
 			return os.real_path(exe)
 		}
-		system_path := os.find_abs_path_of_executable('v.bat') or { '' }
+		system_path := os.find_abs_path_of_executable('v') or { '' }
 		if os.exists(system_path) {
 			exe = os.real_path(system_path)
 		}

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -30,7 +30,7 @@ pub fn vexe() string {
 			if res.exit_code != 0 {
 				return ''
 			}
-			return res.output.trim('\n')
+			return res.output.trim('\n\r')
 		}
 	}
 	return exe

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -5,6 +5,8 @@ module vxt
 import os
 import regex
 
+// vexe returns the path to the `v` compiler if found
+// on the host platform, otherwise a blank `string`.
 pub fn vexe() string {
 	mut exe := os.getenv('VEXE')
 	$if !windows {
@@ -17,18 +19,18 @@ pub fn vexe() string {
 		}
 	} $else {
 		if os.exists(exe) {
-			return os.real_path(exe)
+			return exe
 		}
 		system_path := os.find_abs_path_of_executable('v') or { '' }
 		if os.exists(system_path) {
-			exe = os.real_path(system_path)
+			exe = system_path
 		}
 		if !os.exists(exe) {
 			res := os.execute('where.exe v')
 			if res.exit_code != 0 {
 				return ''
 			}
-			return os.real_path(res.output)
+			return res.output.trim('\n')
 		}
 	}
 	return exe

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -23,6 +23,13 @@ pub fn vexe() string {
 		if os.exists(system_path) {
 			exe = os.real_path(system_path)
 		}
+		if !os.exists(exe) {
+			res := os.execute('where.exe v')
+			if res.exit_code != 0 {
+				return ''
+			}
+			return os.real_path(res.output)
+		}
 	}
 	return exe
 }

--- a/vxt/vxt.v
+++ b/vxt/vxt.v
@@ -44,8 +44,14 @@ pub fn home() string {
 	// credits to @spytheman:
 	// https://discord.com/channels/592103645835821068/592294828432424960/746040606358503484
 	exe := vexe()
-	if os.is_executable(exe) {
-		return os.dir(exe)
+	$if !windows {
+		if os.is_executable(exe) {
+			return os.dir(exe)
+		}
+	} $else {
+		if os.exists(exe) {
+			return os.dir(exe)
+		}
 	}
 	return ''
 }


### PR DESCRIPTION
This PR adds support for building Android apps on Windows.

The current setup works like on Linux and mac but with the following differences:
* Needs Java >= 9 (Though currently only tested locally with Java 11 and 17, Java 8 has problems with V's newly added zip achiver (missing/broken Zip64 support))
* Needs build-tools >= 26.0.2

The bootstrapping process has also been improved - but needs more testing in general.
Deployment to a physical device is (still) untested.

There's a lot of cleaning up to do due to the ad-hoc patches that had to be introduced to make some of the tools work.
This PR still serves as a good starting point for further fixing and cleaning up the process.

I'm planing on encapsulating the retrieval and invoking of the packaging tools in separate functions to make things a bit more readable and thus making the patching more controlled/centralised. This needs to be done anyway to support the new `d8` dexing tool that replaces `dx`/`dx.bat` in newer build-tool versions.

(V UI tests in CI are temporarily disabled since there's a lot of development going on at the moment).