### PR TITLE
fix error for casting to generic in vab_error_test.v

### DIFF
--- a/tests/vab_error_test.v
+++ b/tests/vab_error_test.v
@@ -65,12 +65,12 @@ fn test_all() {
 	assert true
 }
 
-struct TOMLTestJob {
+pub struct TOMLTestJob {
 	env_vars map[string]string
 	job_file string
 }
 
-struct TOMLTestJobResult {
+pub struct TOMLTestJobResult {
 	success            bool
 	job                TOMLTestJob
 	command            string


### PR DESCRIPTION
This PR fix error for casting to generic in vab_error_test.v.