### PR TITLE
compile: deprecate `--no-printf-hijack` field

### DIFF
--- a/android/compile.v
+++ b/android/compile.v
@@ -27,16 +27,15 @@ pub:
 	work_dir string // temporary work directory
 	input    string
 	//
-	is_prod          bool
-	gles_version     int = android.default_gles_version
-	no_printf_hijack bool     // Do not let V redefine printf for log output aka. V_ANDROID_LOG_PRINT
-	archs            []string // compile for these CPU architectures
-	v_flags          []string // flags to pass to the v compiler
-	c_flags          []string // flags to pass to the C compiler(s)
-	ndk_version      string   // version of the Android NDK to compile against
-	lib_name         string   // filename of the resulting .so ('${lib_name}.so')
-	api_level        string   // Android API level to use when compiling
-	min_sdk_version  int = default_min_sdk_version
+	is_prod         bool
+	gles_version    int = android.default_gles_version
+	archs           []string // compile for these CPU architectures
+	v_flags         []string // flags to pass to the v compiler
+	c_flags         []string // flags to pass to the C compiler(s)
+	ndk_version     string   // version of the Android NDK to compile against
+	lib_name        string   // filename of the resulting .so ('${lib_name}.so')
+	api_level       string   // Android API level to use when compiling
+	min_sdk_version int = default_min_sdk_version
 }
 
 // uses_gc returns true if a `-gc` flag is found among the passed v flags.
@@ -108,7 +107,9 @@ fn (err CompileError) msg() string {
 	return 'failed to compile $enum_to_text:\n$err.err'
 }
 
-// compile_v_to_c compiles V into sources to their C counterpart.
+// compile_v_to_c compiles V sources to their Android comptible C counterpart.
+// compile_v_to_c will also compile any supported C dependencies a vlib module might have.
+// See also: compile_v_imports_c_dependencies
 pub fn compile_v_to_c(opt CompileOptions) !VMetaInfo {
 	err_sig := @MOD + '.' + @FN
 	os.mkdir_all(opt.work_dir) or {
@@ -306,15 +307,6 @@ pub fn compile(opt CompileOptions) ! {
 	cflags << ['-Wno-missing-braces', '-Werror=implicit-function-declaration']
 	cflags << ['-Wno-enum-conversion', '-Wno-unused-value', '-Wno-pointer-sign',
 		'-Wno-incompatible-pointer-types']
-
-	// NOTE This define allows V to redefine C's printf() - to let logging via println() etc. go
-	// through Android device's system log (that adb logcat reads).
-	if !opt.no_printf_hijack {
-		if opt.verbosity > 1 {
-			println('Define V_ANDROID_LOG_PRINT - (f)printf will be redefined...')
-		}
-		defines << '-DV_ANDROID_LOG_PRINT'
-	}
 
 	defines << '-DAPPNAME="$opt.lib_name"'
 	defines << ['-DANDROID', '-D__ANDROID__', '-DANDROIDVERSION=$opt.api_level']

--- a/android/compile.v
+++ b/android/compile.v
@@ -107,7 +107,7 @@ fn (err CompileError) msg() string {
 	return 'failed to compile $enum_to_text:\n$err.err'
 }
 
-// compile_v_to_c compiles V sources to their Android comptible C counterpart.
+// compile_v_to_c compiles V sources to their Android compatible C counterpart.
 // compile_v_to_c will also compile any supported C dependencies a vlib module might have.
 // See also: compile_v_imports_c_dependencies
 pub fn compile_v_to_c(opt CompileOptions) !VMetaInfo {

--- a/cli/cli.v
+++ b/cli/cli.v
@@ -99,7 +99,7 @@ pub fn args_to_options(arguments []string, defaults Options) !(Options, &flag.Fl
 		libs_extra: fp.string_multi('libs', `a`, 'Lib dir(s) to include in build')
 		v_flags: fp.string_multi('flag', `f`, 'Additional flags for the V compiler')
 		//
-		no_printf_hijack: fp.bool('no-printf-hijack', 0, defaults.no_printf_hijack, 'Do not let V redefine printf for log output (aka. do not define V_ANDROID_LOG_PRINT)')
+		no_printf_hijack: fp.bool('no-printf-hijack', 0, defaults.no_printf_hijack, 'DEPRECATED NOT NEEDED ANYMORE. Do not let V redefine printf for log output (aka. do not define V_ANDROID_LOG_PRINT)')
 		c_flags: fp.string_multi('cflag', `c`, 'Additional flags for the C compiler')
 		archs: fp.string('archs', 0, defaults.archs.join(','), 'Comma separated string with any of $android.default_archs').split(',')
 		gles_version: fp.int('gles', 0, defaults.gles_version, 'GLES version to use from any of $android.supported_gles_versions')
@@ -142,6 +142,11 @@ pub fn args_to_options(arguments []string, defaults Options) !(Options, &flag.Fl
 		list_ndks: fp.bool('list-ndks', 0, defaults.list_ndks, 'List available NDK versions')
 		list_apis: fp.bool('list-apis', 0, defaults.list_apis, 'List available API levels')
 		list_build_tools: fp.bool('list-build-tools', 0, defaults.list_build_tools, 'List available Build-tools versions')
+	}
+
+	// TODO just user facing notice - can be removed after deprecatioon period is over 2023-03-24
+	if opt.no_printf_hijack {
+		println('--no-printf-hijack is DEPRECATED - it has no effect anymore. See: https://github.com/vlang/v/pull/14984')
 	}
 
 	opt.additional_args = fp.finalize() or {

--- a/cli/options.v
+++ b/cli/options.v
@@ -18,7 +18,7 @@ pub:
 	cache        bool // defaults to false in os.args/flag parsing phase
 	gles_version int = android.default_gles_version
 	// Build specifics
-	no_printf_hijack bool // Do not let V redefine printf for log output aka. V_ANDROID_LOG_PRINT
+	no_printf_hijack bool [deprecated: 'No longer supported since https://github.com/vlang/v/pull/14984'; deprecated_after: '2023-03-24'] // Do not let V redefine printf for log output aka. V_ANDROID_LOG_PRINT
 	// Deploy specifics
 	run              bool
 	device_log       bool
@@ -531,7 +531,7 @@ pub fn (opt &Options) as_android_compile_options() android.CompileOptions {
 		parallel: opt.parallel
 		is_prod: opt.is_prod
 		gles_version: opt.gles_version
-		no_printf_hijack: opt.no_printf_hijack
+		// no_printf_hijack: opt.no_printf_hijack // deprecated and not part of V codebase anymore, can be removed after 2023-03-24
 		v_flags: opt.v_flags
 		c_flags: opt.c_flags
 		archs: opt.archs


### PR DESCRIPTION
This PR deprecates `--no-printf-hijack` since it has no effect anymore.
See the fix https://github.com/vlang/v/pull/14984
