### PR TITLE
sdk: fix const race condition, fix #244

### DIFF
--- a/v.mod
+++ b/v.mod
@@ -1,6 +1,6 @@
 Module {
 	name: 'vab'
 	description: 'V Android Bootstrapper'
-	version: '0.3.6'
+	version: '0.3.7'
 	dependencies: []
 }


### PR DESCRIPTION
Closes #244 
It's presumably caused by a `const`-initialization race condition in the `android.sdk` module.