### PR TITLE
vab: add hint if `run` is specified without `--device`

### DIFF
--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -127,8 +127,8 @@ jobs:
         vab -g --package-id "io.v.ci.vab.apk.examples.tetris" run v/examples/tetris
         sleep 5
         adb -e logcat -d > /tmp/logcat.dump.txt
-        echo "Looking for traces of 'SOKOL_APP: NativeActivity'"
-        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: NativeActivity'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        echo "Looking for traces of SOKOL_APP ok ..."
+        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
 
         # Remove app in case cache is run
         echo "Uninstalling v/examples/tetris"
@@ -164,8 +164,8 @@ jobs:
         vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
         sleep 5
         adb -e logcat -d > /tmp/logcat.dump.txt
-        echo "Looking for traces of 'SOKOL_APP: NativeActivity'"
-        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: NativeActivity'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        echo "Looking for traces of SOKOL_APP ok ..."
+        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
 
         # Remove app in case cache is run
         echo "Uninstalling ui/examples/calculator"

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -124,11 +124,11 @@ jobs:
 
         # Output test
         echo "Testing if v/examples/tetris can run..."
-        vab --package-id "io.v.ci.vab.apk.examples.tetris" run v/examples/tetris
+        vab -g --package-id "io.v.ci.vab.apk.examples.tetris" run v/examples/tetris
         sleep 5
         adb -e logcat -d > /tmp/logcat.dump.txt
-        echo "Looking for traces of SOKOL_APP ok ..."
-        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        echo "Looking for traces of 'SOKOL_APP: NativeActivity'"
+        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: NativeActivity'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
 
         # Remove app in case cache is run
         echo "Uninstalling v/examples/tetris"
@@ -161,11 +161,11 @@ jobs:
 
         # Output test
         echo "Testing if ui/examples/calculator can run..."
-        vab --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
+        vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
         sleep 5
         adb -e logcat -d > /tmp/logcat.dump.txt
-        echo "Looking for traces of SOKOL_APP ok ..."
-        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: ... ok'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        echo "Looking for traces of 'SOKOL_APP: NativeActivity'"
+        cat /tmp/logcat.dump.txt | grep -q 'SOKOL_APP: NativeActivity'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
 
         # Remove app in case cache is run
         echo "Uninstalling ui/examples/calculator"

--- a/vab.v
+++ b/vab.v
@@ -178,6 +178,10 @@ fn main() {
 		if opt.verbosity > 0 {
 			println('Generated ${os.real_path(opt.output)}')
 			println('Use `${cli.exe_short_name} --device <id> ${os.real_path(opt.output)}` to deploy package')
+			if deploy_opt.run != '' {
+				println('Use `${cli.exe_short_name} --device <id> run ${os.real_path(opt.output)}` to run the app on the device, or with adb:')
+				println('Use `adb -s "<DEVICE ID>" shell am start -n "${deploy_opt.run}"` to run the app on the device')
+			}
 		}
 	}
 }

--- a/vab.v
+++ b/vab.v
@@ -178,9 +178,9 @@ fn main() {
 		if opt.verbosity > 0 {
 			println('Generated ${os.real_path(opt.output)}')
 			println('Use `${cli.exe_short_name} --device <id> ${os.real_path(opt.output)}` to deploy package')
+			println('Use `${cli.exe_short_name} --device <id> run ${os.real_path(opt.output)}` to both deploy and run the package')
 			if deploy_opt.run != '' {
-				println('Use `${cli.exe_short_name} --device <id> run ${os.real_path(opt.output)}` to run the app on the device, or with adb:')
-				println('Use `adb -s "<DEVICE ID>" shell am start -n "${deploy_opt.run}"` to run the app on the device')
+				println('Use `adb -s "<DEVICE ID>" shell am start -n "${deploy_opt.run}"` to run the app on the device, via adb')
 			}
 		}
 	}


### PR DESCRIPTION
This will echo a hint on how to start any *manually* deployed packages if `run` is used without setting `--device`