### PR TITLE
vab: add screenshot functionality

### DIFF
--- a/android/adb.v
+++ b/android/adb.v
@@ -1,0 +1,112 @@
+// Copyright(C) 2019-2022 Lars Pontoppidan. All rights reserved.
+// Use of this source code is governed by an MIT license file distributed with this software package
+module android
+
+import os
+import time
+import vab.android.util
+import vab.android.env
+
+// adb_get_device_list returns a list of Android devices available on the system.
+pub fn adb_get_device_list(verbosity int) ![]string {
+	error_tag := '${@MOD}.${@FN}'
+	if !env.has_adb() {
+		return error('${error_tag}: Could not locate "adb". Please make sure it is installed.')
+	}
+	adb := env.adb()
+
+	adb_list_cmd := [
+		adb,
+		'devices',
+		'-l',
+	]
+	util.verbosity_print_cmd(adb_list_cmd, verbosity) // opt.verbosity
+	output := util.run_or_error(adb_list_cmd)!
+	mut device_list := []string{}
+	for device in output.split('\n') {
+		if !device.contains(' model:') {
+			continue
+		}
+		device_list << device.all_before(' ')
+	}
+	return device_list
+}
+
+// adb_log_dump returns the log output by running `adb -s <device id> logcat -d`
+pub fn adb_log_dump(device_id string, verbosity int) !string {
+	adb := env.adb()
+	time.sleep(150 * time.millisecond)
+	adb_logcat_cmd := [
+		adb,
+		'-s',
+		'${device_id}',
+		'logcat',
+		'-d',
+	]
+	util.verbosity_print_cmd(adb_logcat_cmd, verbosity)
+	log_dump := util.run_or_error(adb_logcat_cmd)!
+	return log_dump
+}
+
+// adb_screenshot takes a screenshot of `device_id` and save it to `outfile`.
+// Currently only .png files are supported.
+pub fn adb_screenshot(device_id string, out_file string) ! {
+	if !out_file.ends_with('.png') {
+		return error('${@MOD}.${@FN}: only .png files are supported when taking screenshots')
+	}
+	if os.exists(out_file) {
+		return error('${@MOD}.${@FN}: ${out_file} already exists')
+	}
+	adb := env.adb()
+	// adb exec-out screencap -p > screen.png
+	// From: https://stackoverflow.com/a/37191719/1904615
+	mut adb_screenshot_cmd := [
+		adb,
+		'-s',
+		'${device_id}',
+		'exec-out',
+		'screencap -p',
+		'> ${out_file}',
+	]
+	util.run_or_error(adb_screenshot_cmd)!
+}
+
+// device_list returns a list of connected Android devices.s
+pub fn device_list() []string {
+	return adb_get_device_list(0) or { return []string{} }
+}
+
+// ensure_device_id ensures that the device with `id` is available, and connected.
+// If `'auto'` is passed as `id` ensure_device_id will return the first available device.
+pub fn ensure_device_id(id string, verbosity int) !string {
+	error_tag := '${@MOD}.${@FN}'
+	if !env.has_adb() {
+		return error('${error_tag}: Could not locate "adb". Please make sure it is installed.')
+	}
+	mut device_id := id
+
+	devices := adb_get_device_list(verbosity) or {
+		return error('${error_tag}: Failed getting device list:\n${err}')
+	}
+
+	if device_id == 'auto' {
+		mut auto_device := ''
+		if devices.len > 0 {
+			auto_device = devices.first()
+		}
+		device_id = auto_device
+
+		if device_id == '' {
+			return error('${error_tag}: Could not find any connected devices.')
+		}
+	}
+
+	if device_id != '' {
+		// Do this check in case the device was *not* auto-detected
+		if device_id !in devices {
+			return error('${error_tag}: Could not locate device "${device_id}" in device list.')
+		}
+		return device_id
+	}
+	return error('${error_tag}: Could not ensure device id "${device_id}".')
+}

--- a/android/env/env.v
+++ b/android/env/env.v
@@ -651,7 +651,8 @@ pub fn sdkmanager_version() string {
 }
 
 pub fn has_adb() bool {
-	return adb() != ''
+	adb_path := adb()
+	return adb_path != '' && os.is_executable(adb_path)
 }
 
 pub fn adb() string {

--- a/android/screenshot.v
+++ b/android/screenshot.v
@@ -1,0 +1,248 @@
+// Copyright(C) 2019-2022 Lars Pontoppidan. All rights reserved.
+// Use of this source code is governed by an MIT license file distributed with this software package
+module android
+
+import os
+import time
+import vab.util as vabutil
+import vab.android.env
+import vab.android.util
+
+[params]
+pub struct SimpleScreenshotOptions {
+pub:
+	verbosity int
+	device_id string
+	path      string // /path/to/screenshot.png
+	delay     f64    // delay this many seconds before taking the shot
+}
+
+pub struct ScreenshotOptions {
+pub:
+	deploy_options DeployOptions // This should be copy of the deploy options used to deploy the app
+	path           string        // /path/to/screenshot.png
+	delay          f64 // delay this many seconds before taking the shot
+	on_log         string
+	on_log_timeout f64 // Values <= 0 means no timeout
+}
+
+fn resolve_screenshot_output(input string) !(string, string) {
+	mut out_file := os.file_name(input)
+	mut out_dir := input.trim_string_right(os.path_separator)
+	if out_file.ends_with('.png') {
+		out_dir = os.dir(out_dir)
+	} else if os.is_dir(out_dir) {
+		date := time.now()
+		date_str := date.format_ss_milli().replace_each([' ', '', '.', '', '-', '', ':', ''])
+		shot_filename := os.join_path('${date_str}.png')
+		out_file = shot_filename
+	}
+	return out_dir, out_file
+}
+
+// resolve_output returns the resolved output directory path and the filename.
+pub fn (so ScreenshotOptions) resolve_output() !(string, string) {
+	return resolve_screenshot_output(so.path)
+}
+
+pub fn simple_screenshot(opt SimpleScreenshotOptions) ! {
+	do_screenshot := opt.path != ''
+	if !do_screenshot {
+		return
+	}
+
+	device_id := ensure_device_id(opt.device_id, opt.verbosity) or {
+		return error('${@MOD}.${@FN}:\n${err}')
+	}
+	// Screenshot requested, but no device has been set
+	if do_screenshot && device_id == '' {
+		return error('${@MOD}.${@FN}: Taking screenshots requires a device id. Set one via --device or ANDROID_SERIAL')
+	}
+	out_dir, out_file := resolve_screenshot_output(opt.path)!
+	vabutil.ensure_path(out_dir)!
+
+	output := os.join_path(out_dir, out_file)
+
+	enable_delay := opt.delay > 0
+	if enable_delay {
+		if opt.verbosity > 1 {
+			println('Sleeping ${opt.delay:.2f} seconds before screenshot...')
+		}
+		time.sleep(opt.delay * time.second)
+	}
+
+	// Do a one-off screenshot
+	if opt.verbosity > 0 {
+		println('Taking screenshot to "${output}"')
+	}
+	adb_screenshot(device_id, output)!
+}
+
+// screenshot takes a screenshot on a device and save it on the host machine.
+pub fn screenshot(opt ScreenshotOptions) ! {
+	do_screenshot := opt.path != ''
+	if !do_screenshot {
+		return
+	}
+
+	deploy_opt := opt.deploy_options
+	verbosity := deploy_opt.verbosity
+
+	device_id := ensure_device_id(deploy_opt.device_id, deploy_opt.verbosity) or {
+		return error('${@MOD}.${@FN}:\n${err}')
+	}
+	// Screenshot requested, but no device has been set
+	if do_screenshot && device_id == '' {
+		return error('${@MOD}.${@FN}: Taking screenshots requires a device id. Set one via --device or ANDROID_SERIAL')
+	}
+
+	out_dir, out_file := opt.resolve_output()!
+	vabutil.ensure_path(out_dir)!
+
+	output := os.join_path(out_dir, out_file)
+	if os.exists(output) {
+		return error('${@MOD}.${@FN}: output file "${output}" already exists')
+	}
+
+	do_screenshot_on_log_line := opt.on_log != ''
+	enable_delay := opt.delay > 0
+
+	if enable_delay {
+		if verbosity > 1 {
+			println('Sleeping ${opt.delay:.2f} seconds before screenshot...')
+		}
+		time.sleep(opt.delay * time.second)
+	}
+	if !do_screenshot_on_log_line {
+		// Do a one-off screenshot
+		if verbosity > 0 {
+			println('Taking screenshot to "${output}"')
+		}
+		adb_screenshot(device_id, output)!
+	} else {
+		// Adelay a specified log line to appear
+		screenshot_on_log_line(opt)!
+	}
+}
+
+enum ScreenshotLogExitReason {
+	ok
+	error
+	crash
+	search_string_found
+	timeout
+}
+
+// screenshot_on_log_line takes a screenshot when a specified string
+// appears in the Android log output.
+pub fn screenshot_on_log_line(opt ScreenshotOptions) ! {
+	do_screenshot := opt.path != ''
+	if !do_screenshot {
+		return
+	}
+
+	deploy_opt := opt.deploy_options
+	verbosity := deploy_opt.verbosity
+
+	device_id := ensure_device_id(deploy_opt.device_id, deploy_opt.verbosity) or {
+		return error('${@MOD}.${@FN}:\n${err}')
+	}
+	// Screenshot requested, but no device has been set
+	if do_screenshot && device_id == '' {
+		return error('${@MOD}.${@FN}: Taking screenshots requires a device id. Set one via --device or ANDROID_SERIAL')
+	}
+
+	out_dir, out_file := opt.resolve_output()!
+	vabutil.ensure_path(out_dir)!
+
+	output := os.join_path(out_dir, out_file)
+	if os.exists(output) {
+		return error('${@MOD}.${@FN}: output file "${output}" already exists')
+	}
+
+	enable_delay := opt.delay > 0
+	enable_timeout := opt.on_log_timeout > 0
+
+	if !env.has_adb() {
+		return error('${@MOD}.${@FN}: Could not locate "adb". Please make sure it is installed.')
+	}
+	adb := env.adb()
+
+	mut adb_logcat_cmd := [
+		adb,
+		'-s',
+		'${device_id}',
+		'logcat',
+		'-d',
+	]
+
+	adb_logcat_cmd << deploy_opt.gen_logcat_filters()
+
+	if enable_delay {
+		if verbosity > 1 {
+			println('Sleeping ${opt.delay:.2f} seconds before screenshot...')
+		}
+		time.sleep(opt.delay * time.second)
+	}
+	if verbosity > 0 {
+		println('Monitoring log output for "${opt.on_log}" on device "${device_id}"')
+	}
+	if !enable_timeout {
+		println('Ctrl+C to exit in case the screenshot is never taken')
+	} else {
+		if verbosity > 1 {
+			println('The screenshot attempt will timeout after ${opt.on_log_timeout} seconds')
+		}
+	}
+
+	mut exit_mode := ScreenshotLogExitReason.ok
+
+	util.verbosity_print_cmd(adb_logcat_cmd, verbosity)
+
+	mut log_lines := ''
+	mut timeout_watch := time.new_stopwatch()
+	for {
+		log_lines = util.run_or_error(adb_logcat_cmd) or {
+			exit_mode = .crash
+			break
+		}
+		if log_lines.contains('beginning of crash') {
+			exit_mode = .crash
+			break
+		}
+		if log_lines.contains(opt.on_log) {
+			exit_mode = .search_string_found
+			break
+		}
+		if enable_timeout {
+			elapsed := timeout_watch.elapsed().seconds()
+			timeout := opt.on_log_timeout
+			if elapsed >= timeout {
+				exit_mode = .timeout
+				break
+			}
+		}
+		time.sleep(64 * time.millisecond)
+	}
+	if exit_mode in [.ok, .search_string_found] {
+		if verbosity > 0 {
+			println('Taking screenshot to "${output}"')
+		}
+		adb_screenshot(device_id, output)!
+	} else {
+		match exit_mode {
+			.crash {
+				return error('${@MOD}.${@FN}: taking screenshot failed because the application crashed. Log lines:\n${log_lines}')
+			}
+			.error {
+				return error('${@MOD}.${@FN}: taking screenshot failed because running adb failed. Log lines:\n${log_lines}')
+			}
+			.timeout {
+				return error('${@MOD}.${@FN}: taking screenshot failed because the timeout (${opt.on_log_timeout}) was reached. Log lines:\n${log_lines}')
+			}
+			else {
+				return error('${@MOD}.${@FN}: taking screenshot failed for unknown reasons. Log lines:\n${log_lines}')
+			}
+		}
+	}
+}

--- a/cli/cli.v
+++ b/cli/cli.v
@@ -142,6 +142,11 @@ pub fn args_to_options(arguments []string, defaults Options) !(Options, &flag.Fl
 		list_ndks: fp.bool('list-ndks', 0, defaults.list_ndks, 'List available NDK versions')
 		list_apis: fp.bool('list-apis', 0, defaults.list_apis, 'List available API levels')
 		list_build_tools: fp.bool('list-build-tools', 0, defaults.list_build_tools, 'List available Build-tools versions')
+		//
+		screenshot: fp.string('screenshot', 0, '', 'Take a screenshot on a device and save it to /path/to/file.png or /path/to/directory')
+		screenshot_delay: fp.float('screenshot-delay', 0, 0.0, 'Wait for this amount of seconds before taking screenshot')
+		screenshot_on_log: fp.string('screenshot-on-log', 0, '', 'Wait for this string to appear in the device log before taking a screenshot')
+		screenshot_on_log_timeout: fp.float('screenshot-on-log-timeout', 0, 0.0, 'Timeout after this amount of seconds if --screenshot-on-log string is not detected')
 	}
 
 	// TODO just user facing notice - can be removed after deprecatioon period is over 2023-03-24

--- a/cli/options.v
+++ b/cli/options.v
@@ -29,6 +29,11 @@ pub:
 	list_ndks        bool
 	list_apis        bool
 	list_build_tools bool
+	// screenshot functionality
+	screenshot                string // /path/to/screenshot.png
+	screenshot_delay          f64
+	screenshot_on_log         string
+	screenshot_on_log_timeout f64 = -1.0
 pub mut:
 	// I/O
 	input           string
@@ -582,4 +587,16 @@ pub fn (opt &Options) as_android_package_options() android.PackageOptions {
 		overrides_path: opt.package_overrides_path
 	}
 	return pck_opt
+}
+
+// as_android_screenshot_options returns `android.ScreenshotOptions` based on the fields in `Options`.
+pub fn (opt &Options) as_android_screenshot_options(deploy_opts android.DeployOptions) android.ScreenshotOptions {
+	screenshot_opt := android.ScreenshotOptions{
+		deploy_options: deploy_opts
+		path: opt.screenshot
+		delay: opt.screenshot_delay
+		on_log: opt.screenshot_on_log
+		on_log_timeout: opt.screenshot_on_log_timeout
+	}
+	return screenshot_opt
 }

--- a/util/util.v
+++ b/util/util.v
@@ -1,0 +1,14 @@
+// Copyright(C) 2023 Lars Pontoppidan. All rights reserved.
+// Use of this source code is governed by an MIT license file distributed with this software package
+module util
+
+import os
+
+// ensure_path creates `path` if it does not already exist.
+pub fn ensure_path(path string) ! {
+	if !os.exists(path) {
+		os.mkdir_all(path) or {
+			return error('${@MOD}.${@FN}: error while making directory "${path}":\n${err}')
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a few new functions and flags for taking/controlling screenshots.

The new flags added:
```
--screenshot                "/path/to/file.png or /path/to/directory" - if blank, no screenshot will be attempted
--screenshot-delay          > 0.0 wait for x amount of seconds before taking the screenshot
--screenshot-on-log         "some string in log output" wait for this string to appear in the device log before taking a screenshot
--screenshot-on-log-timeout > 0.0  a safe-guard timeout that abort taking the screenshot if --screenshot-on-log string is not detected
```
I had to move around some code to enable just running `vab --screenshot /tmp` which is a nice simple feature to have IMO. The rest of the flags is minded towards later use with `v gret` to detect visual regressions in CI.

Note that it is possible to use `--screenshot-on-log` *without* specifying a timeout via `--screenshot-on-log-timeout`, in which case `vab` will block until the user hits Ctrl+C or the log line appears. This is, among other use-cases, helpful when debugging/developing the screenshot feature.

An example command for checking if an app builds, packages, deploys, runs *and* looks like you expect would then be:
`vab -g --device <ID> --log-clear --screenshot /tmp/rotating_textured_quad.png --screenshot-on-log 'SOKOL_APP: ... ok' --screenshot-on-log-timeout 5 run ~/Projects/v/examples/gg/rotating_textured_quad.v`
... which will build, package, deploy, start and then wait a maximum of 5 seconds for log line "SOKOL_APP: ... ok" to appear in the app's output. If the line appears, it saves the screenshot as `/tmp/rotating_textured_quad.png` and exits with success - if not, after 5 seconds, an error is printed along with a dump of the log it has tried to parse. Dumping the log on errors is a good way to skim for/detect any misconfiguration or unexpected output.

On top I had to insert small `time.sleep()` calls after certain adb commands, since this improves the deploy and launch cycle a lot.