### PR TITLE
Add --list-devices CLI flag

### DIFF
--- a/cli/cli.v
+++ b/cli/cli.v
@@ -142,6 +142,7 @@ pub fn args_to_options(arguments []string, defaults Options) !(Options, &flag.Fl
 		list_ndks: fp.bool('list-ndks', 0, defaults.list_ndks, 'List available NDK versions')
 		list_apis: fp.bool('list-apis', 0, defaults.list_apis, 'List available API levels')
 		list_build_tools: fp.bool('list-build-tools', 0, defaults.list_build_tools, 'List available Build-tools versions')
+		list_devices: fp.bool('list-devices', 0, defaults.list_devices, 'List available device IDs (including running emulators)')
 		//
 		screenshot: fp.string('screenshot', 0, '', 'Take a screenshot on a device and save it to /path/to/file.png or /path/to/directory')
 		screenshot_delay: fp.float('screenshot-delay', 0, 0.0, 'Wait for this amount of seconds before taking screenshot')

--- a/cli/options.v
+++ b/cli/options.v
@@ -29,6 +29,7 @@ pub:
 	list_ndks        bool
 	list_apis        bool
 	list_build_tools bool
+	list_devices     bool
 	// screenshot functionality
 	screenshot                string // /path/to/screenshot.png
 	screenshot_delay          f64

--- a/vab.v
+++ b/vab.v
@@ -71,6 +71,17 @@ fn main() {
 		}
 		exit(0)
 	}
+
+	if opt.list_devices {
+		devices := android.adb_get_device_list(opt.verbosity) or {
+			eprintln('Error getting device list: ${err}')
+			exit(1)
+		}
+		println('Device IDs:\n')
+		println(devices.join('\n'))
+		exit(0)
+	}
+
 	// All flags after this requires an input argument, except
 	// doing one-off screenshots on a device
 	if fp.args.len == 0 {


### PR DESCRIPTION
This PR allows us to run `vab --list-devices` to list the devices we can deploy our Android app to.

This is useful whenever `--device auto` is too crude, such as when we have multiple physical or emulated devices connected.