### PR TITLE
opt.output: default file name (for apk or aab) is now name of the work dir

### DIFF
--- a/cli/options.v
+++ b/cli/options.v
@@ -302,8 +302,14 @@ pub fn (mut opt Options) resolve_output() {
 		output_file = opt.output
 		opt.package_format = output_file_ext // apk / aab
 	} else { // Generate from defaults: vab [-o <output>] <input>
-		default_file_name := opt.app_name.replace(os.path_separator.str(), '').replace(' ',
+		mut default_file_name := ''
+		if opt.app_name == android.default_app_name {
+			default_file_name = os.getwd().all_after_last('/').replace(os.path_separator.str(), '').replace(' ',
 			'_').to_lower()
+		} else {
+			default_file_name = opt.app_name.replace(os.path_separator.str(), '').replace(' ',
+			'_').to_lower()
+		}
 		if opt.output != '' {
 			ext := os.file_ext(opt.output)
 			if ext != '' {

--- a/examples/bezier/app.v
+++ b/examples/bezier/app.v
@@ -1,0 +1,33 @@
+module main
+
+import gg
+import gx
+
+const points = [f32(200.0), 200.0, 200.0, 100.0, 400.0, 100.0, 400.0, 300.0]
+
+struct App {
+mut:
+	gg &gg.Context = unsafe { nil }
+	i u8
+}
+
+fn main() {
+	mut app := &App{}
+	app.gg = gg.new_context(
+		bg_color: gx.rgb(174, 198, 255)
+		width: 768
+		height: 1024
+		window_title: 'Curve'
+		frame_fn: frame
+		user_data: app
+		sample_count: 4 // higher quality curves
+	)
+	app.gg.run()
+}
+
+fn frame(mut app App) {
+	app.gg.begin()
+	o := app.i++ % 256
+	app.gg.draw_cubic_bezier(points, gx.rgb(o, 255 - o, 255))
+	app.gg.end()
+}


### PR DESCRIPTION
What this PR does and why
---
When issuing `vab .` or `vab run .` the default file name produced is based on a hard-coded string (V Test App). This PR changes the default file name produced to the work dir (similar to what v compiler does).

Why
---
The default .apk or .aac file name is not matching with the expectation of how a `v .` does, hence this PR.
