### PR TITLE
ci: disable java 8 runs due to unavailable sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,10 +342,10 @@ jobs:
       VAB_FLAGS: -cg -v 3 --api 30 --build-tools 30.0.3
     steps:
 
-    #- uses: actions/setup-java@v2
-      #with:
-        #distribution: 'adopt'
-        #java-version: 15
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 11
 
     - name: Install V
       uses: vlang/setup-v@v1

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 8
+        java-version: 11
 
     - name: Install V
       uses: vlang/setup-v@v1
@@ -69,12 +69,12 @@ jobs:
           /Users/runner/Library/Android/sdk/system-images/android-30
         key: ${{ runner.os }}-android-emulator-${{ hashFiles('/Users/runner/.android/avd') }}
 
-    - name: Prepare emulator
-      if: steps.cache-emulator.outputs.cache-hit != 'true'
-      run: |
-        export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
-        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;google_apis;x86_64'
-        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi google_apis/x86_64 --package 'system-images;android-30;google_apis;x86_64'
+    # - name: Prepare emulator
+    #   if: steps.cache-emulator.outputs.cache-hit != 'true'
+    #   run: |
+    #     export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
+    #     echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;google_apis;x86_64'
+    #     echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi google_apis/x86_64 --package 'system-images;android-30;google_apis;x86_64'
 
     - name: Install and run V + V UI examples as APK and AAB
       run: |

--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        java-version: [8,11,15,20]
+        java-version: [11, 15, 20]
         android-api: [27, 30]
       fail-fast: false
     timeout-minutes: 20
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        java-version: [8, 15, 20]
+        java-version: [15, 20]
         android-api: [27, 30]
     timeout-minutes: 20
     env:


### PR DESCRIPTION
Should be temporary change if compatibility with java 8 restored. But should fix most of the current CI failure.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
