### PR TITLE
compile: separate common compiler flags from each individual arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     env:
-      VAB_FLAGS: -cg -v 3 --api 30 --build-tools 30.0.3
+      VAB_FLAGS: -cg -v 3 --api 31 --build-tools 30.0.3
     steps:
 
     #- uses: actions/setup-java@v2

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -139,41 +139,42 @@ jobs:
         adb uninstall io.v.ci.vab.apk.examples.tetris
 
         # V UI
-        echo "Installing V UI"
-        git clone --depth 1 https://github.com/vlang/ui
-        cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
-
-        declare -a v_ui_examples=('rectangles.v')
-
-        echo "Compiling examples ${v_ui_examples[@]}"
-        for example in "${v_ui_examples[@]}"; do
-          package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
-          package_id=$( echo "v$package_id" )
-
-          # APK
-          echo "Compiling apk from ui/examples/$example ($package_id)"
-          vab --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
-
-          # AAB
-          echo "Compiling aab from ui/examples/$example ($package_id)"
-          vab --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
-
-          # Remove app in case cache is run
-          adb uninstall "io.v.apk.ui.$package_id"
-          adb uninstall "io.v.aab.ui.$package_id"
-        done
-
-        # Output test
-        echo "Testing if ui/examples/calculator can run..."
-        vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
-        sleep 5
-        adb -e logcat -d > /tmp/logcat.dump.txt
-        echo "Looking for traces of BDWGC"
-        cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
-
-        # Remove app in case cache is run
-        echo "Uninstalling ui/examples/calculator"
-        adb uninstall io.v.ui.ci.examples.calculator
+        # V UI is currently not in a state where it can be compiled for Android
+        # echo "Installing V UI"
+        # git clone --depth 1 https://github.com/vlang/ui
+        # cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
+        #
+        # declare -a v_ui_examples=('rectangles.v')
+        #
+        # echo "Compiling examples ${v_ui_examples[@]}"
+        # for example in "${v_ui_examples[@]}"; do
+        #   package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
+        #   package_id=$( echo "v$package_id" )
+        #
+        #   # APK
+        #   echo "Compiling apk from ui/examples/$example ($package_id)"
+        #   vab --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
+        #
+        #   # AAB
+        #   echo "Compiling aab from ui/examples/$example ($package_id)"
+        #   vab --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
+        #
+        #   # Remove app in case cache is run
+        #   adb uninstall "io.v.apk.ui.$package_id"
+        #   adb uninstall "io.v.aab.ui.$package_id"
+        # done
+        #
+        # # Output test
+        # echo "Testing if ui/examples/calculator can run..."
+        # vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
+        # sleep 5
+        # adb -e logcat -d > /tmp/logcat.dump.txt
+        # echo "Looking for traces of BDWGC"
+        # cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+        #
+        # # Remove app in case cache is run
+        # echo "Uninstalling ui/examples/calculator"
+        # adb uninstall io.v.ui.ci.examples.calculator
 
         echo "Killing emulator"
         adb -s emulator-5554 emu kill

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 45
     env:
       VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 29.0.0 --device auto --log-clear --archs x86_64
-      V_FLAGS: -no-parallel
+      VFLAGS: -no-parallel
     steps:
     - uses: actions/setup-java@v2
       with:

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 45
     env:
       VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 29.0.0 --device auto --log-clear --archs x86_64
+      V_FLAGS: -no-parallel
     steps:
     - uses: actions/setup-java@v2
       with:
@@ -139,42 +140,41 @@ jobs:
         adb uninstall io.v.ci.vab.apk.examples.tetris
 
         # V UI
-        # V UI is currently not in a state where it can be compiled for Android
-        # echo "Installing V UI"
-        # git clone --depth 1 https://github.com/vlang/ui
-        # cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
-        #
-        # declare -a v_ui_examples=('rectangles.v')
-        #
-        # echo "Compiling examples ${v_ui_examples[@]}"
-        # for example in "${v_ui_examples[@]}"; do
-        #   package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
-        #   package_id=$( echo "v$package_id" )
-        #
-        #   # APK
-        #   echo "Compiling apk from ui/examples/$example ($package_id)"
-        #   vab --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
-        #
-        #   # AAB
-        #   echo "Compiling aab from ui/examples/$example ($package_id)"
-        #   vab --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
-        #
-        #   # Remove app in case cache is run
-        #   adb uninstall "io.v.apk.ui.$package_id"
-        #   adb uninstall "io.v.aab.ui.$package_id"
-        # done
-        #
-        # # Output test
-        # echo "Testing if ui/examples/calculator can run..."
-        # vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
-        # sleep 5
-        # adb -e logcat -d > /tmp/logcat.dump.txt
-        # echo "Looking for traces of BDWGC"
-        # cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
-        #
-        # # Remove app in case cache is run
-        # echo "Uninstalling ui/examples/calculator"
-        # adb uninstall io.v.ui.ci.examples.calculator
+        echo "Installing V UI"
+        git clone --depth 1 https://github.com/vlang/ui
+        cd ui ; mkdir -p ~/.vmodules ; ln -s $(pwd) ~/.vmodules/ui ; cd ..
+
+        declare -a v_ui_examples=('rectangles.v')
+
+        echo "Compiling examples ${v_ui_examples[@]}"
+        for example in "${v_ui_examples[@]}"; do
+          package_id=$( echo "$example" | sed 's%/%%' | sed 's%\.%%' )
+          package_id=$( echo "v$package_id" )
+
+          # APK
+          echo "Compiling apk from ui/examples/$example ($package_id)"
+          vab --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
+
+          # AAB
+          echo "Compiling aab from ui/examples/$example ($package_id)"
+          vab --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
+
+          # Remove app in case cache is run
+          adb uninstall "io.v.apk.ui.$package_id"
+          adb uninstall "io.v.aab.ui.$package_id"
+        done
+
+        # Output test
+        echo "Testing if ui/examples/calculator can run..."
+        vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
+        sleep 5
+        adb -e logcat -d > /tmp/logcat.dump.txt
+        echo "Looking for traces of BDWGC"
+        cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
+
+        # Remove app in case cache is run
+        echo "Uninstalling ui/examples/calculator"
+        adb uninstall io.v.ui.ci.examples.calculator
 
         echo "Killing emulator"
         adb -s emulator-5554 emu kill

--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
     timeout-minutes: 20
     env:
-      VAB_FLAGS: -v 3 --build-tools 29.0.0
+      VAB_FLAGS: -v 3 --build-tools 29.0.0 --api 34 # 35 breaks aapt2 when packaging
     steps:
     - uses: actions/setup-java@v2
       with:

--- a/.github/workflows/matrix_ci.yml
+++ b/.github/workflows/matrix_ci.yml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java-version: [11,15,20]
-        android-api: [27, 30]
+        android-api: [31, 33]
       fail-fast: false
     timeout-minutes: 20
     env:
-      VAB_FLAGS: -v 3 --build-tools 29.0.0 --api 34 # 35 breaks aapt2 when packaging
+      VAB_FLAGS: -v 3 --build-tools 29.0.0
     steps:
     - uses: actions/setup-java@v2
       with:
@@ -97,7 +97,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java-version: [11, 15, 20]
-        android-api: [27, 30]
+        android-api: [31, 33]
     timeout-minutes: 20
     env:
       VAB_FLAGS: -v 3 -gc none --build-tools 29.0.0
@@ -161,7 +161,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java-version: [8] # 9, 10 is in a bad state currently
-        android-api: [27, 30]
+        android-api: [31, 33]
       fail-fast: false
     timeout-minutes: 20
     env:

--- a/android/compile.v
+++ b/android/compile.v
@@ -605,14 +605,14 @@ pub fn compile_v_imports_c_dependencies(opt CompileOptions, imported_modules []s
 	is_debug_build := opt.is_debug_build()
 
 	// For all compilers
-	mut cflags := opt.c_flags.clone()
+	mut cflags_common := opt.c_flags.clone()
 	if opt.is_prod {
-		cflags << ['-Os']
+		cflags_common << ['-Os']
 	} else {
-		cflags << ['-O0']
+		cflags_common << ['-O0']
 	}
-	cflags << ['-fPIC']
-	cflags << ['-Wall', '-Wextra']
+	cflags_common << ['-fPIC']
+	cflags_common << ['-Wall', '-Wextra']
 
 	mut android_includes := []string{}
 	// Include NDK headers
@@ -628,6 +628,7 @@ pub fn compile_v_imports_c_dependencies(opt CompileOptions, imported_modules []s
 
 	mut jobs := []job_util.ShellJob{}
 	for arch in archs {
+		mut cflags := cflags_common.clone()
 		arch_o_dir := os.join_path(build_dir, 'o', arch)
 		if !os.is_dir(arch_o_dir) {
 			os.mkdir_all(arch_o_dir) or {


### PR DESCRIPTION
.. also fix a bunch of CI errors when using `aapt2` with API level 35/`android-35` and also for V UI