### PR TITLE
compile: add support for `#flag /path/to/x.o` V code (better C dependency support)

### DIFF
--- a/android/compile.v
+++ b/android/compile.v
@@ -718,8 +718,8 @@ pub fn compile_v_c_dependencies(opt CompileOptions, v_meta_info VMetaInfo) !VImp
 		}
 
 		// Compile all detected `#flag /path/to/xxx.o` V source code entires that matches an imported module.
-		// NOTE: currently there's no way in V source to pass flags for specific architectures to these flags need
-		// to be added specially here. It should probably be supported as compile options from commandline?
+		// NOTE: currently there's no way in V source to pass flags for specific architectures so these flags need
+		// to be added specially here. It should probably be supported as compile options from commandline...
 		for module_name, mod_compile_lines in v_module_o_files {
 			if opt.verbosity > 1 {
 				println('Compiling .o files from module ${module_name} for arch ${arch}...')

--- a/android/compile.v
+++ b/android/compile.v
@@ -677,7 +677,7 @@ pub fn compile_v_c_dependencies(opt CompileOptions, v_meta_info VMetaInfo) !VImp
 			return error('${err_sig}: failed getting NDK compiler.\n${err}')
 		}
 
-		// libgc is a builtin feature that currently can not be detected via any `-dump-xxx` flags.
+		// Support builtin libgc which is enabled by default in V or via explicit passed `-gc` flag.
 		if uses_gc {
 			if opt.verbosity > 1 {
 				println('Compiling libgc (${arch}) via -gc flag')


### PR DESCRIPTION
This PR adds support for compiling `#flag /path/to/x.o` entries (in V source code) with all supported Android compilers.
This reduces the special-cases needed in `vab` for compiling C dependency object files. This basically means it is now possible to compile V code with your own C dependencies out of the box.

Since there's no way to pass a flag for a specific Android arch in V, there may still be cases where compiling for a specific arch may fail (see e.g. special-case for [`stbi_image_resize2.h`](https://github.com/vlang/vab/blob/master/android/compile.v#L687-L692) that is preserved in this PR).

I have attached an example of an app running unmodified that uses my [wren](https://github.com/larpon/wren) wrapper project (all is included in .zip) - this illustrates that `vab` (in this PR) is now compiling the module's [`#flag *.o` entries](https://github.com/larpon/wren/blob/b1ad7abc5ef73399e7481fdd4f163484a319d1da/c/c.c.v#L19-L27) without any hacks or special-cases needed.
[v_wren_and_json_on_android.zip](https://github.com/user-attachments/files/16740296/v_wren_and_json_on_android.zip)

Since the function signature would otherwise change for the `compile_v_imports_c_dependencies()` function - I choose to deprecate it in favor of a new function `compile_v_c_dependencies`. The functions are very similar but would break userland code.

I have tested compiling and running of a few V examples that import's `stbi` (via `gg`) to ensure uninterrupted user experience.