### PR TITLE
ci: use faster `aosp_atd` avd variant instead of `google_apis` in legacy emulator

### DIFF
--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -130,7 +130,7 @@ jobs:
         # Output test
         echo "Testing if v/examples/tetris can run..."
         vab -g --package-id "io.v.ci.vab.apk.examples.tetris" run v/examples/tetris
-        sleep 5 # give the emulator a little time to start...
+        sleep 5 # give the emulator a little time to start the application...
         adb -e logcat -d > /tmp/logcat.dump.txt
         echo "Looking for traces of BDWGC"
         cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
@@ -161,7 +161,7 @@ jobs:
         # Output test
         echo "Testing if ui/examples/calculator can run..."
         vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
-        sleep 5 # give the emulator a little time to start...
+        sleep 5 # give the emulator a little time to start the application...
         adb -e logcat -d > /tmp/logcat.dump.txt
         echo "Looking for traces of BDWGC"
         cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 45
     env:
-      VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 33.0.2 --device auto --log-clear --archs x86
+      VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 33.0.2 --device auto --log-clear --archs x86_64
       VFLAGS: -no-parallel
     steps:
     - uses: actions/setup-java@v4
@@ -108,7 +108,8 @@ jobs:
 
         # 'flappylearning' can build but running is currently broken on Android
         # Skip fireworks for now
-        declare -a v_examples=('2048' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
+        # declare -a v_examples=('2048' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
+        declare -a v_examples=('tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
 
         echo "Compiling V examples ${v_examples[@]}"
         for example in "${v_examples[@]}"; do

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -119,8 +119,8 @@ jobs:
           echo "Compiling apk from examples/$example ($package_id)"
           vab --package-id "io.v.apk.$package_id" run v/examples/$example
 
-          sleep 1 # try catching a small breath
-        
+          sleep 1
+
           # AAB
           echo "Compiling aab from examples/$example ($package_id)"
           vab --package aab --package-id "io.v.aab.$package_id" run v/examples/$example

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -103,6 +103,7 @@ jobs:
         # Test deployment of single file *after* build
         echo "Testing vab deployment *after* build"
         vab --package-id "io.v.ci.vab.apk.deploytest" --name "V DEPLOY TEST APK" v/examples/gg/bezier.v && vab v_deploy_test_apk.apk
+        sleep 1 # Experience tells us that the emulator likes to catch it's breath...
         vab --package-id "io.v.ci.vab.aab.deploytest" --name "V DEPLOY TEST AAB" --package aab v/examples/gg/bezier.v && vab v_deploy_test_aab.aab
 
         # 'flappylearning' can build but running is currently broken on Android
@@ -119,7 +120,7 @@ jobs:
           echo "Compiling apk from examples/$example ($package_id)"
           vab --package-id "io.v.apk.$package_id" run v/examples/$example
 
-          sleep 1
+          sleep 1 # Experience tells us that the emulator likes to catch it's breath...
 
           # AAB
           echo "Compiling aab from examples/$example ($package_id)"
@@ -129,7 +130,7 @@ jobs:
         # Output test
         echo "Testing if v/examples/tetris can run..."
         vab -g --package-id "io.v.ci.vab.apk.examples.tetris" run v/examples/tetris
-        sleep 5
+        sleep 5 # give the emulator a little time to start...
         adb -e logcat -d > /tmp/logcat.dump.txt
         echo "Looking for traces of BDWGC"
         cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi
@@ -150,6 +151,8 @@ jobs:
           echo "Compiling apk from ui/examples/$example ($package_id)"
           vab --package-id "io.v.apk.ui.$package_id" run ui/examples/$example
 
+          sleep 1 # Experience tells us that the emulator likes to catch it's breath...
+
           # AAB
           echo "Compiling aab from ui/examples/$example ($package_id)"
           vab --package aab --package-id "io.v.aab.ui.$package_id" run ui/examples/$example
@@ -158,7 +161,7 @@ jobs:
         # Output test
         echo "Testing if ui/examples/calculator can run..."
         vab -g --package-id "io.v.ui.ci.examples.calculator" run ui/examples/calculator.v
-        sleep 5
+        sleep 5 # give the emulator a little time to start...
         adb -e logcat -d > /tmp/logcat.dump.txt
         echo "Looking for traces of BDWGC"
         cat /tmp/logcat.dump.txt | grep -q 'BDWGC   : Grow'; if [ ! $? -eq 0 ]; then cat /tmp/logcat.dump.txt; fi

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -83,8 +83,8 @@ jobs:
       if: steps.cache-emulator.outputs.cache-hit != 'true'
       run: |
         export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
-        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;aosp_atd;x86'
-        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi aosp_atd/x86 --package 'system-images;android-30;aosp_atd;x86'
+        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;aosp_atd;x86_64'
+        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi aosp_atd/x86_64 --package 'system-images;android-30;aosp_atd;x86_64'
 
     - name: Install and run V + V UI examples as APK and AAB
       run: |

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -119,6 +119,8 @@ jobs:
           echo "Compiling apk from examples/$example ($package_id)"
           vab --package-id "io.v.apk.$package_id" run v/examples/$example
 
+          sleep 1 # try catching a small breath
+        
           # AAB
           echo "Compiling aab from examples/$example ($package_id)"
           vab --package aab --package-id "io.v.aab.$package_id" run v/examples/$example

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 45
     env:
-      VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 33.0.2 --device auto --log-clear --archs x86_64
+      VAB_FLAGS: -cg -f '-d no_load_styles' -v 3 --api 30 --build-tools 33.0.2 --device auto --log-clear --archs x86
       VFLAGS: -no-parallel
     steps:
     - uses: actions/setup-java@v4
@@ -83,8 +83,8 @@ jobs:
       if: steps.cache-emulator.outputs.cache-hit != 'true'
       run: |
         export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
-        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;aosp_atd;x86_64'
-        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi aosp_atd/x86_64 --package 'system-images;android-30;aosp_atd;x86_64'
+        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;aosp_atd;x86'
+        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi aosp_atd/x86 --package 'system-images;android-30;aosp_atd;x86'
 
     - name: Install and run V + V UI examples as APK and AAB
       run: |

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -108,8 +108,7 @@ jobs:
 
         # 'flappylearning' can build but running is currently broken on Android
         # Skip fireworks for now
-        # declare -a v_examples=('2048' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
-        declare -a v_examples=('tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
+        declare -a v_examples=('2048' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/bezier.v' 'gg/bezier_anim.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
 
         echo "Compiling V examples ${v_examples[@]}"
         for example in "${v_examples[@]}"; do

--- a/.github/workflows/ci_emulator_run.yml
+++ b/.github/workflows/ci_emulator_run.yml
@@ -83,8 +83,8 @@ jobs:
       if: steps.cache-emulator.outputs.cache-hit != 'true'
       run: |
         export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
-        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;google_apis;x86_64'
-        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi google_apis/x86_64 --package 'system-images;android-30;google_apis;x86_64'
+        echo yes | $ANDROID_SDK_ROOT/tools/bin/sdkmanager 'system-images;android-30;aosp_atd;x86_64'
+        echo no | $ANDROID_SDK_ROOT/tools/bin/avdmanager create avd --force --name test --abi aosp_atd/x86_64 --package 'system-images;android-30;aosp_atd;x86_64'
 
     - name: Install and run V + V UI examples as APK and AAB
       run: |


### PR DESCRIPTION
This PR should, in general, speed up the emulator runs by using a lighter/slimmer system image. (https://android-developers.googleblog.com/2021/10/whats-new-in-scalable-automated-testing.html discovered via https://gist.github.com/mrk-han/66ac1a724456cadf1c93f4218c6060ae)

On top I've added a few `sleep` since this seem to *decrease* deploy failures (*increase* chance of success) - hopefully making everything a bit more reliable.